### PR TITLE
Standardize dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,15 @@ updates:
   - package-ecosystem: bundler
     directory: "/"
     schedule:
-      interval: daily
-    open-pull-requests-limit: 10
+      interval: weekly
+      time: "14:00"
+    open-pull-requests-limit: 100
     insecure-external-code-execution: allow
     registries: "*"
+    groups:
+      minor-gem-update:
+        update-types:
+          - "minor"
+      patch-gem-update:
+        update-types:
+          - "patch"

--- a/test/integration/memory_coordinator_integration_test.rb
+++ b/test/integration/memory_coordinator_integration_test.rb
@@ -19,6 +19,10 @@ class MemoryCoordinatorIntegrationTest < IntegrationTest
 
       # Running:
 
+
+      Finished in 0.123s, 0.123 runs/s, 0.123 assertions/s.
+
+      0 runs, 0 assertions, 0 failures, 0 errors, 0 skips
     EOM
   end
 


### PR DESCRIPTION
Part of an ongoing effort to standardize our dependabot configurations.

- Move to weekly
- Match the open pr limit of similar repositories
- Group minor and patch updates together