### PR TITLE
Add rexml as dependency

### DIFF
--- a/minitest-distributed.gemspec
+++ b/minitest-distributed.gemspec
@@ -47,4 +47,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency('minitest', '~> 5.12')
   spec.add_dependency('redis', '>= 5.0.6', '< 6')
   spec.add_dependency('sorbet-runtime')
+  spec.add_dependency('rexml')
 end


### PR DESCRIPTION
[Junitxml reporter](https://github.com/Shopify/minitest-distributed/blob/effbf641811896cdd772a00f9074c1477c371e5e/lib/minitest/distributed/reporters/junitxml_reporter.rb#L4) requires `rexml/document` causing builds to fails that doesn't have `rexml` defined in their Gemfile.  Adding rexml to the gem dependency.