### PR TITLE
Export Redis log

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -5,3 +5,4 @@ type: ruby
 up:
   - ruby
   - bundler
+  - redis

--- a/lib/minitest/distributed/coordinators/redis_coordinator.rb
+++ b/lib/minitest/distributed/coordinators/redis_coordinator.rb
@@ -3,6 +3,7 @@
 
 require "redis"
 require "set"
+require "logger"
 
 module Minitest
   module Distributed
@@ -268,7 +269,24 @@ module Minitest
 
         sig { returns(Redis) }
         def redis
-          @redis ||= Redis.new(url: configuration.coordinator_uri.to_s)
+          @redis ||= Redis.new(
+            url: configuration.coordinator_uri.to_s,
+            middlewares: custom_middlewares,
+            custom: custom_config,
+          )
+        end
+
+        sig { returns(T.nilable(T::Array[Module])) }
+        def custom_middlewares
+          return unless ENV.key?("MINITEST_DISTRIBUTED_REDIS_LOG")
+
+          require_relative "redis_instrumentation_middleware"
+          [RedisInstrumentationMiddleware]
+        end
+
+        sig { returns(T.nilable(T::Hash[Symbol, File])) }
+        def custom_config
+          { log_file: logger }.compact
         end
 
         sig { returns(String) }
@@ -515,6 +533,13 @@ module Minitest
           end
 
           adjust_combined_results(batch_result_aggregate)
+        end
+
+        sig { returns(T.nilable(Logger)) }
+        def logger
+          return unless (log_path = ENV["MINITEST_DISTRIBUTED_REDIS_LOG"])
+
+          @logger ||= T.let(Logger.new(log_path), T.nilable(Logger))
         end
 
         INITIAL_BACKOFF = 10 # milliseconds

--- a/lib/minitest/distributed/coordinators/redis_instrumentation_middleware.rb
+++ b/lib/minitest/distributed/coordinators/redis_instrumentation_middleware.rb
@@ -1,0 +1,39 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "redis"
+
+module Minitest
+  module Distributed
+    module Coordinators
+      # Redis middleware that logs all Redis commands to a file for debugging.
+      module RedisInstrumentationMiddleware
+        extend T::Sig
+
+        sig { params(command: T::Array[T.untyped], redis_config: T.untyped).returns(T.untyped) }
+        def call(command, redis_config)
+          log_file = redis_config.custom[:log_file]
+          log_file.info("EXEC: #{command.inspect}")
+          result = super
+          log_file.info("RESULT: #{result.inspect}")
+          result
+        rescue => e
+          log_file.info("ERROR: #{e.class}")
+          Kernel.raise
+        end
+
+        sig { params(commands: T::Array[T.untyped], redis_config: T.untyped).returns(T.untyped) }
+        def call_pipelined(commands, redis_config)
+          log_file = redis_config.custom[:log_file]
+          log_file.info("EXEC PIPELINED: #{commands.inspect}")
+          result = super
+          log_file.info("RESULT PIPELINED: #{result.inspect}")
+          result
+        rescue => e
+          log_file.info("ERROR PIPELINED: #{e.class}")
+          Kernel.raise
+        end
+      end
+    end
+  end
+end

--- a/test/integration/redis_coordinator_integration_test.rb
+++ b/test/integration/redis_coordinator_integration_test.rb
@@ -341,4 +341,27 @@ class RedisCoordinatorIntegrationTest < RedisIntegrationTest
     assert_includes(output, "/100] PassingTests#test_pass_0")
     assert_includes(output, "/100] PassingTests#test_pass_99")
   end
+
+  def test_with_redis_log
+    # When we boot workers in our test suite, we pipe the output. As a result, STDOUT is
+    # not a TTY, and by default progress reporting is disabled. This has caused issues in
+    # the past. In this test, we explicitly enable progress reporting so we can exercise
+    # this code even when the output will not be sent to a TTY.
+    Tempfile.open("test_with_redis_log") do |f|
+      workers = spawn_redis_workers(
+        count: 2,
+        test_file: "passing_tests.rb",
+        run_id: "test_with_progress",
+        arguments: { "--test-batch-size" => "5" },
+        env: { "MINITEST_DISTRIBUTED_REDIS_LOG" => f.path },
+      ).map(&:value)
+
+      assert_all_workers_successful(workers)
+
+      log = File.read(T.must(f.path))
+      assert_includes(log, "xpending")
+      assert_includes(log, "mget")
+      assert_includes(log, "xack")
+    end
+  end
 end

--- a/test/lib/redis_integration_test.rb
+++ b/test/lib/redis_integration_test.rb
@@ -34,7 +34,7 @@ class RedisIntegrationTest < IntegrationTest
     #   2) Not the DB in use by any of the other workers.
     #
     # TODO: ensure that every worker uses a different redis in a better way.
-    @redis_uri = "#{ENV.fetch("REDIS_URL", "redis://0.0.0.0:22220")}/#{Kernel.rand(1...16)}"
+    @redis_uri = ENV.fetch("REDIS_URL", "redis://0.0.0.0:22220")
     @redis = Redis.new(url: @redis_uri)
     @redis.flushdb
 


### PR DESCRIPTION
Adding functionality to export a Redis log to help debug in cases of an error.

This helped to find the issue described in https://github.com/Shopify/minitest-distributed/pull/34