### PR TITLE
Bump timeout

### DIFF
--- a/lib/minitest/distributed/coordinators/redis_coordinator.rb
+++ b/lib/minitest/distributed/coordinators/redis_coordinator.rb
@@ -273,6 +273,7 @@ module Minitest
             url: configuration.coordinator_uri.to_s,
             middlewares: custom_middlewares,
             custom: custom_config,
+            timeout: 2,
           )
         end
 

--- a/lib/minitest/distributed/version.rb
+++ b/lib/minitest/distributed/version.rb
@@ -3,6 +3,6 @@
 
 module Minitest
   module Distributed
-    VERSION = "0.2.11"
+    VERSION = "0.2.12"
   end
 end


### PR DESCRIPTION
We sometimes see ReadTimeout errors which will get automatically retried which brings ci-queue in a non recoverable state because `process_batch` is not idempotent.

This is not a proper fix but mitigates the underlying issue and also aligns with what we do in [ci-queue](https://github.com/Shopify/ci-queue/blob/3de93c614c289b5cbc7ddad4df51f7285dce800a/ruby/lib/ci/queue/redis/base.rb#L14). Waiting 2sec here is totally acceptable rather than retry and get into an infinite loop.

```
I, [2026-01-16T16:04:54.756398 #253]  INFO -- : EXEC PIPELINED: [["MULTI"], ["xack", "minitest/019bc789-148b-49cb-a448-d2f18701dc29/queue", "minitest-distributed", "1768579402503-21"], ["xack", "minitest/019bc789-148b-49cb-a448-d2f18701dc29/queue", "minitest-distributed", "1768579402503-22"], ["xack", "minitest/019bc789-148b-49cb-a448-d2f18701dc29/queue", "minitest-distributed", "1768579402503-23"], ["xack", "minitest/019bc789-148b-49cb-a448-d2f18701dc29/queue", "minitest-distributed", "1768579402503-24"], ["xack", "minitest/019bc789-148b-49cb-a448-d2f18701dc29/queue", "minitest-distributed", "1768579402503-25"], ["xack", "minitest/019bc789-148b-49cb-a448-d2f18701dc29/queue", "minitest-distributed", "1768579402503-26"], ["xack", "minitest/019bc789-148b-49cb-a448-d2f18701dc29/queue", "minitest-distributed", "1768579402503-27"], ["xack", "minitest/019bc789-148b-49cb-a448-d2f18701dc29/queue", "minitest-distributed", "1768579402503-28"], ["xack", "minitest/019bc789-148b-49cb-a448-d2f18701dc29/queue", "minitest-distributed", "1768579402503-29"], ["xack", "minitest/019bc789-148b-49cb-a448-d2f18701dc29/queue", "minitest-distributed", "1768579402503-30"], ["EXEC"]]
I, [2026-01-16T16:04:55.759257 #253]  INFO -- : ERROR PIPELINED: RedisClient::ReadTimeoutError
I, [2026-01-16T16:04:55.763367 #253]  INFO -- : EXEC PIPELINED: [["MULTI"], ["xack", "minitest/019bc789-148b-49cb-a448-d2f18701dc29/queue", "minitest-distributed", "1768579402503-21"], ["xack", "minitest/019bc789-148b-49cb-a448-d2f18701dc29/queue", "minitest-distributed", "1768579402503-22"], ["xack", "minitest/019bc789-148b-49cb-a448-d2f18701dc29/queue", "minitest-distributed", "1768579402503-23"], ["xack", "minitest/019bc789-148b-49cb-a448-d2f18701dc29/queue", "minitest-distributed", "1768579402503-24"], ["xack", "minitest/019bc789-148b-49cb-a448-d2f18701dc29/queue", "minitest-distributed", "1768579402503-25"], ["xack", "minitest/019bc789-148b-49cb-a448-d2f18701dc29/queue", "minitest-distributed", "1768579402503-26"], ["xack", "minitest/019bc789-148b-49cb-a448-d2f18701dc29/queue", "minitest-distributed", "1768579402503-27"], ["xack", "minitest/019bc789-148b-49cb-a448-d2f18701dc29/queue", "minitest-distributed", "1768579402503-28"], ["xack", "minitest/019bc789-148b-49cb-a448-d2f18701dc29/queue", "minitest-distributed", "1768579402503-29"], ["xack", "minitest/019bc789-148b-49cb-a448-d2f18701dc29/queue", "minitest-distributed", "1768579402503-30"], ["EXEC"]]
I, [2026-01-16T16:04:55.870561 #253]  INFO -- : RESULT PIPELINED: ["OK", "QUEUED", "QUEUED", "QUEUED", "QUEUED", "QUEUED", "QUEUED", "QUEUED", "QUEUED", "QUEUED", "QUEUED", [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]]
```