### PR TITLE
Add lazy test loading feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ them to fail.
   worker being broken. When the timeout passes, the other workers will assume
   that the worker running the test has crashed, and will attempt to claim this
   test. This value should be comfortably higher than your slowest test.
-- `--max-attempts=NUMBER` or `ENV[MINITEST_MAX_ATTEMPTS]` (default: 3). The
+- `--max-attempts=NUMBER` or `ENV[MINITEST_MAX_ATTEMPTS]` (default: 1). The
   maximum number of times a test is attempted to be run, before considering
   it failed. Higher values will prevent more flakiness, but will make the full
   test run slower.
@@ -87,6 +87,90 @@ them to fail.
 - `--include-file=PATH_TO_FILE`: Specify a file of tests to be included in
   the test run. The file should include test identifiers seperated by
   newlines.
+
+## Lazy Loading
+
+For large test suites, you can enable lazy loading to reduce memory usage on worker nodes. With lazy loading enabled:
+
+- The **leader** worker loads all test files to build a manifest mapping test classes to their source files
+- **Consumer** workers only load test files on-demand as they pick up tests from the queue
+
+This can provide significant memory savings for workers that don't need to run the entire test suite.
+
+### How It Works
+
+Lazy loading has two parts that work together:
+
+1. **Test file discovery** - Collecting test file paths without loading them into memory.
+   - Use `RakeIntegration.apply(t)` which automatically populates `MINITEST_TEST_FILES`, or
+   - Manually set `MINITEST_TEST_FILES` to a comma-separated list of test file paths
+
+2. **Deferred loading** - Workers only load test files when they claim tests from the queue.
+   Enable with `MINITEST_LAZY_LOAD=true`.
+
+Both parts are required for lazy loading to work. The `RakeIntegration` helper replaces
+Rake's default test loader to prevent it from immediately requiring all test files.
+If you use a custom test runner or have a different build system, you can set
+`MINITEST_TEST_FILES` directly instead.
+
+### Using with Rake::TestTask (Recommended)
+
+```ruby
+require "minitest/distributed/rake_integration"
+
+Rake::TestTask.new(:test) do |t|
+  t.libs << "test"
+  t.pattern = "test/**/*_test.rb"
+  t.warning = false
+
+  # Apply lazy loading support when enabled via environment variable.
+  # This replaces Rake's default loader to defer test file loading.
+  Minitest::Distributed::RakeIntegration.apply(t) if ENV["MINITEST_LAZY_LOAD"] == "true"
+end
+```
+
+Then run your tests with:
+
+```bash
+MINITEST_LAZY_LOAD=true \
+  MINITEST_COORDINATOR=redis://localhost/1 \
+  MINITEST_RUN_ID=$BUILD_NUMBER \
+  rake test
+```
+
+### Test Helpers
+
+Use `MINITEST_TEST_HELPERS` when your test setup files contain code that tests depend on
+but won't be autoloaded. Common examples:
+
+- Custom minitest reporters or plugins
+- Database setup and teardown
+- Shared test fixtures or factory definitions
+- Global test configuration
+
+```bash
+MINITEST_LAZY_LOAD=true \
+  MINITEST_TEST_HELPERS=test_helper \
+  MINITEST_COORDINATOR=redis://localhost/1 \
+  MINITEST_RUN_ID=$BUILD_NUMBER \
+  rake test
+```
+
+Multiple helpers can be specified as a comma-separated list: `test_helper,support/factories`.
+
+### Configuration Options
+
+- `--lazy-load` or `MINITEST_LAZY_LOAD=true`: Enable lazy loading mode
+- `--test-helpers=FILES` or `MINITEST_TEST_HELPERS`: Comma-separated list of helper files
+  to load before tests (e.g., `test_helper`)
+
+### Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `MINITEST_LAZY_LOAD` | Set to `true` to enable lazy loading |
+| `MINITEST_TEST_HELPERS` | Comma-separated helper files to load before tests |
+| `MINITEST_TEST_FILES` | Comma-separated test file paths. Set automatically when using `RakeIntegration`, or set manually if using a custom test runner |
 
 **Limitations**
 

--- a/lib/minitest/distributed/configuration.rb
+++ b/lib/minitest/distributed/configuration.rb
@@ -24,6 +24,9 @@ module Minitest
             test_batch_size: Integer(env["MINITEST_TEST_BATCH_SIZE"] || DEFAULT_BATCH_SIZE),
             max_attempts: Integer(env["MINITEST_MAX_ATTEMPTS"] || DEFAULT_MAX_ATTEMPTS),
             max_failures: (max_failures_env = env["MINITEST_MAX_FAILURES"]) ? Integer(max_failures_env) : nil,
+            lazy_load: env["MINITEST_LAZY_LOAD"] == "true",
+            test_helpers: (test_helpers_env = env["MINITEST_TEST_HELPERS"]) ? test_helpers_env.split(",").map(&:strip) : [],
+            test_files: (test_files_env = env["MINITEST_TEST_FILES"]) ? test_files_env.split(",").map(&:strip) : [],
           )
         end
 
@@ -83,6 +86,25 @@ module Minitest
             configuration.shuffle_suites = enabled
           end
 
+          opts.on("--[no-]lazy-load", "Lazy load test files on workers (default: disabled)") do |enabled|
+            configuration.lazy_load = enabled
+          end
+
+          opts.on(
+            "--test-helpers=FILES",
+            "Comma-separated list of helper files to load before tests (used with --lazy-load)",
+          ) do |files|
+            configuration.test_helpers = files.split(",").map(&:strip)
+          end
+
+          opts.on(
+            "--test-files=FILES",
+            "Comma-separated list of test files to run (used with --lazy-load). " \
+              "Set automatically when using RakeIntegration.",
+          ) do |files|
+            configuration.test_files = files.split(",").map(&:strip)
+          end
+
           configuration
         end
       end
@@ -102,6 +124,9 @@ module Minitest
       prop :exclude_file, T.nilable(String)
       prop :include_file, T.nilable(String)
       prop :shuffle_suites, T::Boolean, default: true
+      prop :lazy_load, T::Boolean, default: false
+      prop :test_helpers, T::Array[String], default: []
+      prop :test_files, T::Array[String], default: []
 
       sig { returns(Coordinators::CoordinatorInterface) }
       def coordinator

--- a/lib/minitest/distributed/coordinators/coordinator_interface.rb
+++ b/lib/minitest/distributed/coordinators/coordinator_interface.rb
@@ -26,6 +26,12 @@ module Minitest
 
         sig { abstract.params(reporter: Minitest::AbstractReporter).void }
         def consume(reporter:); end
+
+        sig { abstract.returns(T::Boolean) }
+        def leader?; end
+
+        sig { abstract.returns(Integer) }
+        def files_loaded_count; end
       end
     end
   end

--- a/lib/minitest/distributed/coordinators/memory_coordinator.rb
+++ b/lib/minitest/distributed/coordinators/memory_coordinator.rb
@@ -1,6 +1,8 @@
 # typed: strict
 # frozen_string_literal: true
 
+require "set"
+
 module Minitest
   module Distributed
     module Coordinators
@@ -23,11 +25,21 @@ module Minitest
         def initialize(configuration:)
           @configuration = configuration
 
-          @leader = T.let(Mutex.new, Mutex)
+          @leader_mutex = T.let(Mutex.new, Mutex)
           @queue = T.let(Queue.new, Queue)
           @local_results = T.let(ResultAggregate.new(max_failures: configuration.max_failures), ResultAggregate)
           @aborted = T.let(false, T::Boolean)
+          @is_leader = T.let(false, T::Boolean)
+          @files_loaded_count = T.let(0, Integer)
         end
+
+        sig { override.returns(T::Boolean) }
+        def leader?
+          @is_leader
+        end
+
+        sig { override.returns(Integer) }
+        attr_reader :files_loaded_count
 
         sig { override.params(reporter: Minitest::CompositeReporter, options: T::Hash[Symbol, T.untyped]).void }
         def register_reporters(reporter:, options:)
@@ -41,9 +53,19 @@ module Minitest
 
         sig { override.params(test_selector: TestSelector).void }
         def produce(test_selector:)
-          if @leader.try_lock
+          if @leader_mutex.try_lock
+            @is_leader = true
             tests = test_selector.tests
             @local_results.size = tests.size
+
+            # Count unique source files for test classes
+            source_files = Set.new
+            tests.each do |runnable|
+              source_location = runnable.class.instance_method(runnable.name).source_location&.first
+              source_files.add(source_location) if source_location
+            end
+            @files_loaded_count = source_files.size
+
             if tests.empty?
               queue.close
             else

--- a/lib/minitest/distributed/coordinators/redis_coordinator.rb
+++ b/lib/minitest/distributed/coordinators/redis_coordinator.rb
@@ -62,6 +62,9 @@ module Minitest
         sig { returns(T::Set[EnqueuedRunnable]) }
         attr_reader :reclaimed_failed_tests
 
+        sig { returns(T::Hash[String, String]) }
+        attr_reader :manifest
+
         sig { params(configuration: Configuration).void }
         def initialize(configuration:)
           @configuration = configuration
@@ -74,6 +77,19 @@ module Minitest
           @reclaimed_timeout_tests = T.let(Set.new, T::Set[EnqueuedRunnable])
           @reclaimed_failed_tests = T.let(Set.new, T::Set[EnqueuedRunnable])
           @aborted = T.let(false, T::Boolean)
+          @manifest = T.let({}, T::Hash[String, String])
+          @leader = T.let(false, T::Boolean)
+          @loaded_files = T.let(Set.new, T::Set[String])
+        end
+
+        sig { override.returns(T::Boolean) }
+        def leader?
+          @leader
+        end
+
+        sig { override.returns(Integer) }
+        def files_loaded_count
+          @loaded_files.size
         end
 
         sig { override.params(reporter: Minitest::CompositeReporter, options: T::Hash[Symbol, T.untyped]).void }
@@ -153,7 +169,10 @@ module Minitest
 
           return if consumer_group_exists
 
-          tests = T.let([], T::Array[Minitest::Runnable])
+          @leader = true
+          load_test_files_for_leader if configuration.lazy_load
+
+          T.let([], T::Array[Minitest::Runnable])
           tests = if initial_attempt
             # If this is the first attempt for this run ID, we will schedule the full
             # test suite as returned by the test selector to run.
@@ -211,7 +230,13 @@ module Minitest
             T.let([], T::Array[Minitest::Runnable])
           end
 
+          test_manifest = configuration.lazy_load ? test_selector.test_manifest : {}
+
           redis.pipelined do |pipeline|
+            if configuration.lazy_load && !test_manifest.empty?
+              pipeline.hset(manifest_key, test_manifest)
+            end
+
             tests.each do |test|
               pipeline.xadd(stream_key, { class_name: T.must(test.class.name), method_name: test.name })
             end
@@ -446,6 +471,39 @@ module Minitest
           # so we can assume that all the Redis cleanup was completed.
         end
 
+        sig { void }
+        def fetch_manifest
+          @manifest = redis.hgetall(manifest_key)
+        end
+
+        sig { params(enqueued_runnable: EnqueuedRunnable).void }
+        def ensure_class_loaded_with_manifest_fetch(enqueued_runnable)
+          fetch_manifest if manifest.empty?
+
+          class_name = enqueued_runnable.class_name
+          file_path = manifest[class_name]
+
+          if file_path && !@loaded_files.include?(file_path)
+            load(file_path)
+            @loaded_files.add(file_path)
+          end
+        end
+
+        sig { returns(String) }
+        def manifest_key
+          key("manifest")
+        end
+
+        sig { void }
+        def load_test_files_for_leader
+          return if configuration.test_files.empty?
+
+          configuration.test_files.each do |file_path|
+            load(file_path)
+            @loaded_files.add(file_path)
+          end
+        end
+
         sig { params(results: ResultAggregate).void }
         def adjust_combined_results(results)
           updated = redis.multi do |pipeline|
@@ -494,6 +552,8 @@ module Minitest
 
           # Call `prerecord` on the recorder for all tests in the batch, and run them.
           results = batch.map do |enqueued_runnable|
+            ensure_class_loaded_with_manifest_fetch(enqueued_runnable) if configuration.lazy_load
+
             reporter.prerecord(enqueued_runnable.runnable_class, enqueued_runnable.method_name)
             [enqueued_runnable, enqueued_runnable.run]
           end

--- a/lib/minitest/distributed/enqueued_runnable.rb
+++ b/lib/minitest/distributed/enqueued_runnable.rb
@@ -27,6 +27,8 @@ module Minitest
       end
     end
 
+    class LazyLoadError < StandardError; end
+
     # This module defines some helper methods to deal with Minitest::Runnable
     module DefinedRunnable
       extend T::Sig
@@ -35,6 +37,32 @@ module Minitest
       def self.find_class(name)
         name.split("::")
           .reduce(Object) { |ns, const| ns.const_get(const) } # rubocop:disable Sorbet/ConstantsFromStrings
+      end
+
+      sig { params(name: String, manifest: T::Hash[String, String]).void }
+      def self.load_class_from_manifest(name, manifest)
+        file_path = manifest[name]
+        unless file_path
+          raise LazyLoadError, <<~MSG.chomp
+            Cannot find test file for class '#{name}'.
+            Ensure all workers use the same test files and restart the test run.
+          MSG
+        end
+
+        # Use `load` instead of `require` - the file may already be partially loaded
+        load(file_path)
+      end
+
+      sig { params(name: String).returns(T::Boolean) }
+      def self.class_defined?(name)
+        name.split("::").reduce(Object) do |ns, const|
+          return false unless ns.const_defined?(const, false)
+
+          ns.const_get(const, false) # rubocop:disable Sorbet/ConstantsFromStrings
+        end
+        true
+      rescue NameError
+        false
       end
 
       sig { params(runnable: Minitest::Runnable).returns(String) }
@@ -173,6 +201,11 @@ module Minitest
       sig { returns(Minitest::Runnable) }
       def instantiate_runnable
         runnable_class.new(method_name)
+      end
+
+      sig { params(manifest: T::Hash[String, String]).void }
+      def ensure_class_loaded(manifest)
+        DefinedRunnable.load_class_from_manifest(class_name, manifest)
       end
 
       sig { returns(T::Boolean) }

--- a/lib/minitest/distributed/rake_integration.rb
+++ b/lib/minitest/distributed/rake_integration.rb
@@ -1,0 +1,29 @@
+# typed: true
+# frozen_string_literal: true
+
+require "rake/testtask"
+
+module Minitest
+  module Distributed
+    # Configures Rake::TestTask for lazy loading support.
+    #
+    # @example
+    #   Rake::TestTask.new do |t|
+    #     t.pattern = "test/**/*_test.rb"
+    #     Minitest::Distributed::RakeIntegration.apply(t)
+    #   end
+    module RakeIntegration
+      LOADER_PATH = File.expand_path("rake_test_loader.rb", __dir__)
+
+      class << self
+        # @param task [Rake::TestTask]
+        # @return [Rake::TestTask]
+        def apply(task)
+          task.loader = :direct
+          task.define_singleton_method(:run_code) { %("#{LOADER_PATH}") }
+          task
+        end
+      end
+    end
+  end
+end

--- a/lib/minitest/distributed/rake_test_loader.rb
+++ b/lib/minitest/distributed/rake_test_loader.rb
@@ -1,0 +1,37 @@
+# typed: true
+# frozen_string_literal: true
+
+# Custom test loader for minitest-distributed lazy loading.
+# Replaces Rake's default loader to defer test file loading when MINITEST_LAZY_LOAD=true.
+
+require "rake/file_list"
+
+lazy_load = ENV["MINITEST_LAZY_LOAD"] == "true"
+test_files = []
+
+argv = ARGV.select do |argument|
+  case argument
+  when /^-/
+    true
+  when /\*/
+    Rake::FileList[argument].to_a.each do |file|
+      path = File.expand_path(file)
+      lazy_load ? test_files << path : require(path)
+    end
+    false
+  else
+    path = File.expand_path(argument)
+    abort("\nFile does not exist: #{path}\n\n") unless File.exist?(path)
+    lazy_load ? test_files << path : require(path)
+    false
+  end
+end
+
+if lazy_load && test_files.any?
+  ENV["MINITEST_TEST_FILES"] = test_files.join(",")
+end
+
+ARGV.replace(argv)
+
+# Trigger minitest since test files (which normally require minitest/autorun) weren't loaded
+require "minitest/autorun" if lazy_load

--- a/lib/minitest/distributed/reporters/distributed_summary_reporter.rb
+++ b/lib/minitest/distributed/reporters/distributed_summary_reporter.rb
@@ -39,6 +39,8 @@ module Minitest
             io.puts("This worker:      #{local_results} #{formatted_duration}")
             io.puts("Combined results: #{combined_results}")
           end
+
+          print_worker_stats
         end
 
         sig { override.returns(T::Boolean) }
@@ -54,6 +56,34 @@ module Minitest
         end
 
         protected
+
+        sig { void }
+        def print_worker_stats
+          coordinator = configuration.coordinator
+          role = coordinator.leader? ? "leader" : "consumer"
+          lazy_status = configuration.lazy_load ? "lazy loading enabled" : "lazy loading disabled"
+
+          io.puts
+          io.puts("Worker stats:     #{role}, #{coordinator.files_loaded_count} files loaded, " \
+            "#{peak_memory_mb} MB peak memory, #{lazy_status}")
+        end
+
+        sig { returns(Integer) }
+        def peak_memory_mb
+          if File.exist?("/proc/self/status")
+            status = File.read("/proc/self/status")
+            if (match = status.match(/VmHWM:\s*(\d+)\s*kB/))
+              return match[1].to_i / 1024
+            end
+          end
+
+          rusage = Process.getrusage
+          max_rss = rusage.maxrss
+          # maxrss is bytes on macOS, KB on Linux
+          RUBY_PLATFORM.include?("darwin") ? max_rss / (1024 * 1024) : max_rss / 1024
+        rescue StandardError
+          0
+        end
 
         sig { void }
         def print_discard_warning

--- a/lib/minitest/distributed/test_selector.rb
+++ b/lib/minitest/distributed/test_selector.rb
@@ -66,6 +66,35 @@ module Minitest
       def tests
         select_tests(discover_tests)
       end
+
+      sig { returns(T::Hash[String, String]) }
+      def test_manifest
+        @test_manifest ||= T.let(
+          runnables.each_with_object({}) do |klass, manifest|
+            file_path = source_location_for(klass)
+            if file_path
+              class_name = T.must(klass.name)
+              if manifest.key?(class_name) && manifest[class_name] != file_path
+                warn "[minitest-distributed] WARNING: Duplicate class name '#{class_name}' " \
+                     "found in multiple files:\n  - #{manifest[class_name]}\n  - #{file_path}\n" \
+                     "Only one will be used for lazy loading. Rename one class to avoid test failures."
+              end
+              manifest[class_name] = file_path
+            end
+          end,
+          T.nilable(T::Hash[String, String]),
+        )
+      end
+
+      private
+
+      sig { params(klass: T.class_of(Minitest::Runnable)).returns(T.nilable(String)) }
+      def source_location_for(klass)
+        method_name = klass.runnable_methods.first
+        return unless method_name
+
+        klass.instance_method(method_name).source_location&.first
+      end
     end
   end
 end

--- a/lib/minitest/distributed_plugin.rb
+++ b/lib/minitest/distributed_plugin.rb
@@ -25,6 +25,12 @@ module Minitest
     def plugin_distributed_init(options)
       return if options[:disable_distributed]
 
+      configuration = options[:distributed]
+
+      if configuration.lazy_load
+        configuration.test_helpers.each { |helper_path| require(helper_path) }
+      end
+
       Minitest.singleton_class.prepend(Minitest::Distributed::TestRunnerPatch)
 
       remove_reporter(::Rails::TestUnitReporter) if defined?(::Rails::TestUnitReporter)

--- a/test/fixtures/runner_wrapper.rb
+++ b/test/fixtures/runner_wrapper.rb
@@ -1,0 +1,18 @@
+# typed: false
+# frozen_string_literal: true
+
+# Test runner wrapper for integration tests. Supports eager and lazy loading modes.
+
+require "minitest/autorun"
+
+fixture_file = ARGV.shift
+raise "Usage: runner_wrapper.rb <fixture_file> [args...]" unless fixture_file
+
+fixture_path = File.join(__dir__, fixture_file)
+raise "Fixture not found: #{fixture_path}" unless File.exist?(fixture_path)
+
+if ARGV.include?("--lazy-load")
+  ENV["MINITEST_TEST_FILES"] = fixture_path
+else
+  require fixture_path
+end

--- a/test/integration/memory_coordinator_integration_test.rb
+++ b/test/integration/memory_coordinator_integration_test.rb
@@ -39,6 +39,8 @@ class MemoryCoordinatorIntegrationTest < IntegrationTest
       Run options: --verbose --run-id foo --worker-id bar --enable-distributed --seed 12345
 
       Results: 0 runs, 0 assertions, 0 passes, 0 failures, 0 errors (in 0.123s)
+
+      Worker stats:     leader, 0 files loaded, XX MB peak memory, lazy loading disabled
     EOM
   end
 
@@ -197,6 +199,8 @@ class MemoryCoordinatorIntegrationTest < IntegrationTest
   private
 
   def normalize_output(output)
-    output.gsub(/\d+\.\d+/, "0.123")
+    output
+      .gsub(/\d+\.\d+/, "0.123")
+      .gsub(/\d+ MB peak memory/, "XX MB peak memory")
   end
 end

--- a/test/integration/redis_coordinator_integration_test.rb
+++ b/test/integration/redis_coordinator_integration_test.rb
@@ -3,17 +3,370 @@
 
 require "test_helper"
 
+# Shared test cases that should pass identically with and without lazy loading.
+# Test methods are dynamically defined with names indicating the loading mode.
+module RedisCoordinatorSharedTests
+  class << self
+    def included(base)
+      base.class_eval do
+        define_method("test_no_tests_#{loading_mode}") do
+          runner = spawn_redis_worker(
+            test_file: "no_tests.rb",
+            run_id: "#{test_name_prefix}_no_tests",
+            lazy_load: lazy_load_enabled?,
+          ).value
+
+          assert_worker_successful(runner)
+          assert_output_includes(runner, "0 runs, 0 assertions, 0 passes, 0 failures, 0 errors")
+
+          results = combined_results(run_id: "#{test_name_prefix}_no_tests")
+          assert_predicate(results, :passed?)
+          assert_equal(0, results.unique_runs)
+          assert_equal(0, results.passes)
+          assert_equal(0, results.failures)
+          assert_equal(0, results.errors)
+          assert_equal(0, results.skips)
+        end
+
+        define_method("test_passing_tests_with_one_worker_#{loading_mode}") do
+          runner = spawn_redis_worker(
+            test_file: "passing_tests.rb",
+            run_id: "#{test_name_prefix}_passing_one",
+            lazy_load: lazy_load_enabled?,
+          ).value
+
+          assert_worker_successful(runner)
+          assert_output_includes(runner, "100 runs, 100 assertions, 100 passes, 0 failures, 0 errors")
+
+          results = combined_results(run_id: "#{test_name_prefix}_passing_one")
+          assert_predicate(results, :passed?)
+          assert_equal(100, results.passes)
+          assert_equal(0, results.failures)
+          assert_equal(0, results.errors)
+          assert_equal(0, results.skips)
+        end
+
+        define_method("test_failing_tests_with_one_worker_and_two_attempts_#{loading_mode}") do
+          runner = spawn_redis_worker(
+            test_file: "failing_tests.rb",
+            run_id: "#{test_name_prefix}_failing_one_two_attempts",
+            arguments: {
+              "--test-timeout" => "1",
+              "--test-batch-size" => "1",
+              "--max-attempts" => "2",
+            },
+            lazy_load: lazy_load_enabled?,
+          ).value
+
+          refute_worker_successful(runner)
+          assert_output_includes(runner, "101 runs, 101 assertions, 99 passes, 1 failures, 0 errors, 1 re-queued")
+
+          results = combined_results(run_id: "#{test_name_prefix}_failing_one_two_attempts")
+          refute_predicate(results, :passed?)
+          assert_equal(100, results.unique_runs)
+          assert_equal(99, results.passes)
+          assert_equal(1, results.failures)
+          assert_equal(0, results.errors)
+          assert_equal(0, results.skips)
+        end
+
+        define_method("test_passing_tests_with_multiple_workers_#{loading_mode}") do
+          workers = spawn_redis_workers(
+            count: 3,
+            test_file: "passing_tests.rb",
+            run_id: "#{test_name_prefix}_passing_multi",
+            lazy_load: lazy_load_enabled?,
+          ).map(&:value)
+
+          assert_all_workers_successful(workers)
+
+          results = combined_results(run_id: "#{test_name_prefix}_passing_multi")
+          assert_predicate(results, :passed?)
+          assert_equal(100, results.unique_runs)
+          assert_equal(100, results.passes)
+          assert_equal(0, results.failures)
+          assert_equal(0, results.errors)
+          assert_equal(0, results.skips)
+        end
+
+        define_method("test_failing_tests_with_multiple_workers_#{loading_mode}") do
+          workers = spawn_redis_workers(
+            count: 3,
+            test_file: "failing_tests.rb",
+            run_id: "#{test_name_prefix}_failing_multi",
+            arguments: {
+              "--test-timeout" => "1",
+              "--test-batch-size" => "1",
+              "--max-attempts" => "3",
+            },
+            lazy_load: lazy_load_enabled?,
+          ).map(&:value)
+
+          assert_some_workers_failed(workers)
+
+          results = combined_results(run_id: "#{test_name_prefix}_failing_multi")
+          refute_predicate(results, :passed?)
+          assert_equal(100, results.unique_runs)
+          assert_equal(99, results.passes)
+          assert_equal(1, results.failures)
+          assert_equal(0, results.errors)
+          assert_equal(0, results.skips)
+        end
+
+        define_method("test_crashing_worker_#{loading_mode}") do
+          Tempfile.open("#{test_name_prefix}_crashing_worker") do |f|
+            worker = spawn_redis_worker(
+              test_file: "crashing_tests.rb",
+              run_id: "#{test_name_prefix}_crashing_worker",
+              env: { "CRASH_TRACKER_FILE" => f.path },
+              lazy_load: lazy_load_enabled?,
+            ).value
+
+            assert_equal(9, worker.status.termsig, "Expected worker to have been KILLed.\n#{boxed_workers_output([worker])}")
+          end
+
+          results = combined_results(run_id: "#{test_name_prefix}_crashing_worker")
+          refute_predicate(results, :complete?)
+          assert_predicate(results, :passed?)
+        end
+
+        define_method("test_crashing_worker_with_multiple_workers_#{loading_mode}") do
+          workers = Tempfile.open("#{test_name_prefix}_crashing_multi") do |f|
+            spawn_redis_workers(
+              count: 2,
+              test_file: "crashing_tests.rb",
+              run_id: "#{test_name_prefix}_crashing_multi",
+              arguments: { "--test-batch-size" => "5", "--test-timeout" => "0.1", "--max-attempts" => "3" },
+              env: { "CRASH_TRACKER_FILE" => f.path },
+              lazy_load: lazy_load_enabled?,
+            ).map(&:value)
+          end
+
+          grouped_workers = workers.group_by { |worker| !!worker.status.success? }
+          assert_equal(1, grouped_workers[true]&.size || 0, "Expected 1 worker to succeed\n#{boxed_workers_output(workers)}")
+          assert_equal(1, grouped_workers[false]&.size || 0, "Expected 1 worker to fail\n#{boxed_workers_output(workers)}")
+
+          crashed_worker = grouped_workers[false][0]
+          successful_worker = grouped_workers[true][0]
+
+          assert_output_includes(successful_worker, "WARNING: The following tests were reclaimed from another worker")
+          assert_equal("KILL", Signal.signame(crashed_worker.status.termsig))
+
+          results = combined_results(run_id: "#{test_name_prefix}_crashing_multi")
+          assert_predicate(results, :passed?)
+          assert_equal(100, results.unique_runs)
+          assert_equal(100, results.passes)
+          assert_equal(0, results.failures)
+          assert_equal(0, results.errors)
+          assert_equal(0, results.skips)
+        end
+
+        define_method("test_test_that_is_too_slow_with_enough_workers_#{loading_mode}") do
+          workers = spawn_redis_workers(
+            count: 4,
+            test_file: "slow_test.rb",
+            run_id: "#{test_name_prefix}_slow_enough_workers",
+            arguments: { "--test-batch-size" => "3", "--test-timeout" => "0.05", "--max-attempts" => "3" },
+            env: { "SLEEP_TIME" => "2" },
+            lazy_load: lazy_load_enabled?,
+          ).map(&:value)
+
+          assert_some_workers_failed(workers)
+
+          output = normalize_output(workers_output(workers))
+          assert_includes(output, "WARNING: This worker was not able to ack all the tests it ran with the coordinator")
+          assert_includes(output, "WARNING: The following tests were reclaimed from another worker:")
+          assert_includes(output, "This test takes too long to run (> 0.05s)")
+          assert_includes(output, <<~EOM)
+            Discarded:
+            SlowTest#test_too_slow [/path/to/file.rb:123]:
+            This test result was discarded, because it could not be committed to the test run coordinator.
+          EOM
+
+          results = combined_results(run_id: "#{test_name_prefix}_slow_enough_workers")
+          refute_predicate(results, :passed?)
+          assert_equal(100, results.acks)
+          assert_equal(100, results.unique_runs)
+          assert_equal(99, results.passes)
+          assert_equal(1, results.failures)
+          assert_equal(0, results.errors)
+          assert_equal(0, results.skips)
+        end
+
+        define_method("test_test_that_is_too_slow_with_limited_workers_#{loading_mode}") do
+          workers = spawn_redis_workers(
+            count: 3,
+            test_file: "slow_test.rb",
+            run_id: "#{test_name_prefix}_slow_limited_workers",
+            arguments: { "--test-batch-size" => "3", "--test-timeout" => "0.05", "--max-attempts" => "3" },
+            env: { "SLEEP_TIME" => "1" },
+            lazy_load: lazy_load_enabled?,
+          ).map(&:value)
+
+          assert_all_workers_successful(workers)
+          output = workers_output(workers)
+          assert_includes(output, "WARNING: The following tests were reclaimed from another worker:")
+
+          results = combined_results(run_id: "#{test_name_prefix}_slow_limited_workers")
+          assert_predicate(results, :passed?)
+          assert_equal(100, results.acks)
+          assert_equal(100, results.unique_runs)
+          assert_equal(100, results.passes)
+          assert_equal(0, results.failures)
+          assert_equal(0, results.errors)
+          assert_equal(0, results.skips)
+        end
+
+        define_method("test_flaky_test_fails_with_only_one_attempt_#{loading_mode}") do
+          workers = Tempfile.open("#{test_name_prefix}_flaky_one_attempt") do |f|
+            spawn_redis_workers(
+              count: 3,
+              test_file: "flaky_test.rb",
+              run_id: "#{test_name_prefix}_flaky_one_attempt",
+              arguments: { "--max-attempts" => "1", "--no-retry-failures" => "true" },
+              env: { "FLAKY_TRACKER_FILE" => f.path },
+              lazy_load: lazy_load_enabled?,
+            ).map(&:value)
+          end
+
+          assert_some_workers_failed(workers)
+
+          results = combined_results(run_id: "#{test_name_prefix}_flaky_one_attempt")
+          refute_predicate(results, :passed?)
+          assert_equal(99, results.passes)
+          assert_equal(1, results.failures)
+          assert_equal(0, results.requeues)
+        end
+
+        define_method("test_flaky_test_succeeds_after_second_attempt_with_single_worker_#{loading_mode}") do
+          worker = Tempfile.open("#{test_name_prefix}_flaky_single") do |f|
+            spawn_redis_worker(
+              test_file: "flaky_test.rb",
+              run_id: "#{test_name_prefix}_flaky_single",
+              arguments: { "--max-attempts" => "3", "--no-retry-failures" => "true" },
+              env: { "FLAKY_TRACKER_FILE" => f.path },
+              lazy_load: lazy_load_enabled?,
+            ).value
+          end
+
+          assert_worker_successful(worker)
+
+          results = combined_results(run_id: "#{test_name_prefix}_flaky_single")
+          assert_predicate(results, :passed?)
+          assert_equal(100, results.passes)
+          assert_equal(0, results.failures)
+          assert_equal(1, results.requeues)
+        end
+
+        define_method("test_flaky_test_succeeds_after_second_attempt_with_multiple_workers_#{loading_mode}") do
+          workers = Tempfile.open("#{test_name_prefix}_flaky_multi") do |f|
+            spawn_redis_workers(
+              count: 3,
+              test_file: "flaky_test.rb",
+              run_id: "#{test_name_prefix}_flaky_multi",
+              arguments: { "--max-attempts" => "3", "--no-retry-failures" => "true" },
+              env: { "FLAKY_TRACKER_FILE" => f.path },
+              lazy_load: lazy_load_enabled?,
+            ).map(&:value)
+          end
+
+          assert_all_workers_successful(workers)
+
+          results = combined_results(run_id: "#{test_name_prefix}_flaky_multi")
+          assert_predicate(results, :passed?)
+          assert_equal(100, results.passes)
+          assert_equal(0, results.failures)
+          assert_equal(1, results.requeues)
+        end
+
+        define_method("test_max_failures_with_multiple_workers_#{loading_mode}") do
+          workers = spawn_redis_workers(
+            count: 3,
+            test_file: "only_failures.rb",
+            run_id: "#{test_name_prefix}_max_failures",
+            arguments: { "--max-failures" => "10", "--no-retry-failures" => "true", "--test-batch-size" => "1" },
+            lazy_load: lazy_load_enabled?,
+          ).map(&:value)
+
+          assert_some_workers_failed(workers)
+          assert_includes(workers_output(workers), "The run was cut short after reaching the limit of 10 test failures.")
+
+          results = combined_results(run_id: "#{test_name_prefix}_max_failures", max_failures: 10)
+          refute_predicate(results, :passed?)
+          assert_predicate(results, :valid?)
+          assert_operator(results.failures, :>=, 10)
+        end
+
+        define_method("test_with_progress_#{loading_mode}") do
+          workers = spawn_redis_workers(
+            count: 2,
+            test_file: "passing_tests.rb",
+            run_id: "#{test_name_prefix}_progress",
+            arguments: { "--progress" => "true", "--test-batch-size" => "5" },
+            lazy_load: lazy_load_enabled?,
+          ).map(&:value)
+
+          assert_all_workers_successful(workers)
+
+          output = workers_output(workers)
+          assert_includes(output, "/100] PassingTests#test_pass_0")
+          assert_includes(output, "/100] PassingTests#test_pass_99")
+        end
+      end
+    end
+  end
+end
+
+# Tests without lazy loading (baseline)
+class RedisCoordinatorIntegrationEagerTest < RedisIntegrationTest
+  class << self
+    def loading_mode
+      "eager"
+    end
+  end
+
+  def lazy_load_enabled?
+    false
+  end
+
+  def test_name_prefix
+    "eager"
+  end
+
+  include RedisCoordinatorSharedTests
+end
+
+# Tests with lazy loading enabled
+class RedisCoordinatorIntegrationLazyTest < RedisIntegrationTest
+  class << self
+    def loading_mode
+      "lazy"
+    end
+  end
+
+  def lazy_load_enabled?
+    true
+  end
+
+  def test_name_prefix
+    "lazy"
+  end
+
+  include RedisCoordinatorSharedTests
+end
+
+# Tests that don't need to run in both eager and lazy modes
 class RedisCoordinatorIntegrationTest < RedisIntegrationTest
   def test_no_tests_with_read_timeout
     Toxiproxy[/redis/].downstream(:latency, latency: 100).apply do
       runner = spawn_redis_worker(
         test_file: "no_tests.rb",
-        run_id: "test_no_tests",
+        run_id: "test_no_tests_with_read_timeout",
       ).value
 
       assert_worker_successful(runner)
       assert_output_includes(runner, "0 runs, 0 assertions, 0 passes, 0 failures, 0 errors")
-      results = combined_results(run_id: "test_no_tests")
+      results = combined_results(run_id: "test_no_tests_with_read_timeout")
       assert_predicate(results, :passed?)
       assert_equal(0, results.unique_runs)
       assert_equal(0, results.passes)
@@ -23,335 +376,12 @@ class RedisCoordinatorIntegrationTest < RedisIntegrationTest
     end
   end
 
-  def test_no_tests
-    runner = spawn_redis_worker(
-      test_file: "no_tests.rb",
-      run_id: "test_no_tests",
-    ).value
-
-    assert_worker_successful(runner)
-    assert_output_includes(runner, "0 runs, 0 assertions, 0 passes, 0 failures, 0 errors")
-
-    results = combined_results(run_id: "test_no_tests")
-    assert_predicate(results, :passed?)
-    assert_equal(0, results.unique_runs)
-    assert_equal(0, results.passes)
-    assert_equal(0, results.failures)
-    assert_equal(0, results.errors)
-    assert_equal(0, results.skips)
-  end
-
-  def test_passing_tests_with_one_worker
-    runner = spawn_redis_worker(
-      test_file: "passing_tests.rb",
-      run_id: "test_passing_tests_with_one_worker",
-    ).value
-
-    assert_worker_successful(runner)
-    assert_output_includes(runner, "100 runs, 100 assertions, 100 passes, 0 failures, 0 errors")
-
-    results = combined_results(run_id: "test_passing_tests_with_one_worker")
-    assert_predicate(results, :passed?)
-    assert_equal(100, results.passes)
-    assert_equal(0, results.failures)
-    assert_equal(0, results.errors)
-    assert_equal(0, results.skips)
-  end
-
-  def test_failing_tests_with_one_worker_and_two_attempts
-    runner = spawn_redis_worker(
-      test_file: "failing_tests.rb",
-      run_id: "test_failing_tests_with_one_worker_and_two_attempts",
-      arguments: {
-        "--test-timeout" => "1",
-        "--test-batch-size" => "1",
-        "--max-attempts" => "2",
-      },
-    ).value
-
-    refute_worker_successful(runner)
-    assert_output_includes(runner, "101 runs, 101 assertions, 99 passes, 1 failures, 0 errors, 1 re-queued")
-
-    results = combined_results(run_id: "test_failing_tests_with_one_worker_and_two_attempts")
-    refute_predicate(results, :passed?)
-    assert_equal(100, results.unique_runs)
-    assert_equal(99, results.passes)
-    assert_equal(1, results.failures)
-    assert_equal(0, results.errors)
-    assert_equal(0, results.skips)
-  end
-
-  def test_passing_tests_with_multiple_workers
-    workers = spawn_redis_workers(
-      count: 3,
-      test_file: "passing_tests.rb",
-      run_id: "test_passing_tests_with_multiple_workers",
-    ).map(&:value)
-
-    assert_all_workers_successful(workers)
-
-    results = combined_results(run_id: "test_passing_tests_with_multiple_workers")
-    assert_predicate(results, :passed?)
-    assert_equal(100, results.unique_runs)
-    assert_equal(100, results.passes)
-    assert_equal(0, results.failures)
-    assert_equal(0, results.errors)
-    assert_equal(0, results.skips)
-  end
-
-  def test_failing_tests_with_multiple_workers
-    workers = spawn_redis_workers(
-      count: 3,
-      test_file: "failing_tests.rb",
-      run_id: "test_failing_tests_with_multiple_workers",
-      arguments: {
-        "--test-timeout" => "1",
-        "--test-batch-size" => "1",
-        "--max-attempts" => "3",
-      },
-    ).map(&:value)
-
-    assert_some_workers_failed(workers)
-
-    results = combined_results(run_id: "test_failing_tests_with_multiple_workers")
-    refute_predicate(results, :passed?)
-    assert_equal(100, results.unique_runs)
-    assert_equal(99, results.passes)
-    assert_equal(1, results.failures)
-    assert_equal(0, results.errors)
-    assert_equal(0, results.skips)
-  end
-
-  def test_crashing_worker
-    # The only worker crashes.
-    # The build stats should reflect the build is not complete and not successful.
-
-    Tempfile.open("test_crashing_worker") do |f|
-      worker = spawn_redis_worker(
-        test_file: "crashing_tests.rb",
-        run_id: "test_crashing_worker",
-        env: { "CRASH_TRACKER_FILE" => f.path },
-      ).value
-
-      assert_equal(9, worker.status.termsig, "Expected worker to have been KILLed.\n#{boxed_workers_output([worker])}")
-    end
-
-    results = combined_results(run_id: "test_crashing_worker")
-    refute_predicate(results, :complete?)
-    assert_predicate(results, :passed?)
-  end
-
-  def test_crashing_worker_with_multiple_workers
-    # This test is set up to crash the worker (kill -9) once, but will succeed on the second attempt.
-    # As a result, one test worker will not be successful, but the other ones will be OK.
-    # We expect the build system to be set up for these crashed test workers to not fail the build.
-    # We can check the test statistics in Redis to make sure the full test suite ran successfully.
-
-    workers = Tempfile.open("test_crashing_worker_with_multiple_workers") do |f|
-      spawn_redis_workers(
-        count: 2,
-        test_file: "crashing_tests.rb",
-        run_id: "test_crashing_worker_with_multiple_workers",
-        arguments: { "--test-batch-size" => "5", "--test-timeout" => "0.1", "--max-attempts" => "3" },
-        env: { "CRASH_TRACKER_FILE" => f.path },
-      ).map(&:value)
-    end
-
-    grouped_workers = workers.group_by { |worker| !!worker.status.success? }
-    assert_equal(1, grouped_workers[true]&.size || 0, "Expected 1 worker to succeed\n#{boxed_workers_output(workers)}")
-    assert_equal(1, grouped_workers[false]&.size || 0, "Expected 1 worker to fail\n#{boxed_workers_output(workers)}")
-
-    crashed_worker = grouped_workers[false][0]
-    successful_worker = grouped_workers[true][0]
-
-    assert_output_includes(successful_worker, "WARNING: The following tests were reclaimed from another worker")
-    assert_equal("KILL", Signal.signame(crashed_worker.status.termsig))
-
-    results = combined_results(run_id: "test_crashing_worker_with_multiple_workers")
-    assert_predicate(results, :passed?)
-    assert_equal(100, results.unique_runs)
-    assert_equal(100, results.passes)
-    assert_equal(0, results.failures)
-    assert_equal(0, results.errors)
-    assert_equal(0, results.skips)
-  end
-
-  def test_test_that_is_too_slow_with_enough_workers
-    # Because we have more workers than attempts, one of the workers will eventually
-    # claim it after all the attempts are exhausted, and mark the test as failed.
-    # The other workers will continue to run the test, and eventually mark it as successful locally.
-    # However, they will not be able to acknowledge the test run with Redis, so the build will fail.
-
-    workers = spawn_redis_workers(
-      count: 4,
-      test_file: "slow_test.rb",
-      run_id: "test_test_that_is_too_slow_with_enough_workers",
-      arguments: { "--test-batch-size" => "3", "--test-timeout" => "0.05", "--max-attempts" => "3" },
-      env: { "SLEEP_TIME" => "2" },
-    ).map(&:value)
-
-    # One worker should fail.
-    assert_some_workers_failed(workers)
-
-    output = normalize_output(workers_output(workers))
-    assert_includes(output, "WARNING: This worker was not able to ack all the tests it ran with the coordinator")
-    assert_includes(output, "WARNING: The following tests were reclaimed from another worker:")
-    assert_includes(output, "This test takes too long to run (> 0.05s)")
-    assert_includes(output, <<~EOM)
-      Discarded:
-      SlowTest#test_too_slow [/path/to/file.rb:123]:
-      This test result was discarded, because it could not be committed to the test run coordinator.
-    EOM
-
-    # Even though we have only one test, it will be attempted by 4 workers:
-    # 3 real attempts that are too slow and 1 fail fast attempt that gets acknowledged.
-    results = combined_results(run_id: "test_test_that_is_too_slow_with_enough_workers")
-    refute_predicate(results, :passed?)
-    assert_equal(100, results.acks)
-    assert_equal(100, results.unique_runs)
-    assert_equal(99, results.passes)
-    assert_equal(1, results.failures)
-    assert_equal(0, results.errors)
-    assert_equal(0, results.skips)
-  end
-
-  def test_test_that_is_too_slow_with_limited_workers
-    # When we have fewer workers than retry attemmpts, at some point all workers
-    # will be trying to process the slow test, and there is no worker left to mark is as failed.
-    # As a result, the last worker will not be interruped and will be able to complete the run.
-    workers = spawn_redis_workers(
-      count: 3,
-      test_file: "slow_test.rb",
-      run_id: "test_test_that_is_too_slow_with_limited_workers",
-      arguments: { "--test-batch-size" => "3", "--test-timeout" => "0.05", "--max-attempts" => "3" },
-      env: { "SLEEP_TIME" => "1" },
-    ).map(&:value)
-
-    assert_all_workers_successful(workers)
-    output = workers_output(workers)
-    assert_includes(output, "WARNING: The following tests were reclaimed from another worker:")
-
-    results = combined_results(run_id: "test_test_that_is_too_slow_with_limited_workers")
-    assert_predicate(results, :passed?)
-    assert_equal(100, results.acks)
-    assert_equal(100, results.unique_runs)
-    assert_equal(100, results.passes)
-    assert_equal(0, results.failures)
-    assert_equal(0, results.errors)
-    assert_equal(0, results.skips)
-  end
-
-  def test_flaky_test_fails_with_only_one_attempt
-    workers = Tempfile.open("test_flaky_test_fails_with_only_one_attempt") do |f|
-      spawn_redis_workers(
-        count: 3,
-        test_file: "flaky_test.rb",
-        run_id: "test_flaky_test_fails_with_only_one_attempt",
-        arguments: { "--max-attempts" => "1", "--no-retry-failures" => "true" },
-        env: { "FLAKY_TRACKER_FILE" => f.path },
-      ).map(&:value)
-    end
-
-    assert_some_workers_failed(workers)
-
-    results = combined_results(run_id: "test_flaky_test_fails_with_only_one_attempt")
-
-    refute_predicate(results, :passed?)
-    assert_equal(99, results.passes)
-    assert_equal(1, results.failures)
-    assert_equal(0, results.requeues)
-  end
-
-  def test_flaky_test_succeeds_after_second_attempt_with_single_worker
-    worker1 = Tempfile.open("test_flaky_test_succeeds_after_second_attempt_with_single_worker") do |f|
-      spawn_redis_worker(
-        test_file: "flaky_test.rb",
-        run_id: "test_flaky_test_succeeds_after_second_attempt_with_single_worker",
-        arguments: { "--max-attempts" => "3", "--no-retry-failures" => "true" },
-        env: { "FLAKY_TRACKER_FILE" => f.path },
-      ).value
-    end
-
-    assert_worker_successful(worker1)
-
-    results = combined_results(run_id: "test_flaky_test_succeeds_after_second_attempt_with_single_worker")
-
-    assert_predicate(results, :passed?)
-    assert_equal(100, results.passes)
-    assert_equal(0, results.failures)
-    assert_equal(1, results.requeues)
-  end
-
-  def test_flaky_test_succeeds_after_second_attempt_with_multiple_workers
-    workers = Tempfile.open("test_flaky_test_succeeds_after_second_attempt_with_multiple_workers") do |f|
-      spawn_redis_workers(
-        count: 3,
-        test_file: "flaky_test.rb",
-        run_id: "test_flaky_test_succeeds_after_second_attempt_with_multiple_workers",
-        arguments: { "--max-attempts" => "3", "--no-retry-failures" => "true" },
-        env: { "FLAKY_TRACKER_FILE" => f.path },
-      ).map(&:value)
-    end
-
-    assert_all_workers_successful(workers)
-
-    results = combined_results(run_id: "test_flaky_test_succeeds_after_second_attempt_with_multiple_workers")
-
-    assert_predicate(results, :passed?)
-    assert_equal(100, results.passes)
-    assert_equal(0, results.failures)
-    assert_equal(1, results.requeues)
-  end
-
-  def test_max_failures_with_multiple_workers
-    workers = spawn_redis_workers(
-      count: 3,
-      test_file: "only_failures.rb",
-      run_id: "test_max_failures_with_multiple_workers",
-      arguments: { "--max-failures" => "10", "--no-retry-failures" => "true", "--test-batch-size" => "1" },
-    ).map(&:value)
-
-    assert_some_workers_failed(workers)
-    assert_includes(workers_output(workers), "The run was cut short after reaching the limit of 10 test failures.")
-
-    results = combined_results(run_id: "test_max_failures_with_multiple_workers", max_failures: 10)
-    refute_predicate(results, :passed?)
-    assert_predicate(results, :valid?)
-
-    # Once one worker decided to abort the run, the other workers will complete their tests
-    # that are in progress before they will exit, increasing the number of failures.
-    assert_operator(results.failures, :>=, 10)
-  end
-
-  def test_with_progress
-    # When we boot workers in our test suite, we pipe the output. As a result, STDOUT is
-    # not a TTY, and by default progress reporting is disabled. This has caused issues in
-    # the past. In this test, we explicitly enable progress reporting so we can exercise
-    # this code even when the output will not be sent to a TTY.
-    workers = spawn_redis_workers(
-      count: 2,
-      test_file: "passing_tests.rb",
-      run_id: "test_with_progress",
-      arguments: { "--progress" => "true", "--test-batch-size" => "5" },
-    ).map(&:value)
-
-    assert_all_workers_successful(workers)
-
-    output = workers_output(workers)
-    assert_includes(output, "/100] PassingTests#test_pass_0")
-    assert_includes(output, "/100] PassingTests#test_pass_99")
-  end
-
   def test_with_redis_log
-    # When we boot workers in our test suite, we pipe the output. As a result, STDOUT is
-    # not a TTY, and by default progress reporting is disabled. This has caused issues in
-    # the past. In this test, we explicitly enable progress reporting so we can exercise
-    # this code even when the output will not be sent to a TTY.
     Tempfile.open("test_with_redis_log") do |f|
       workers = spawn_redis_workers(
         count: 2,
         test_file: "passing_tests.rb",
-        run_id: "test_with_progress",
+        run_id: "test_with_redis_log",
         arguments: { "--test-batch-size" => "5" },
         env: { "MINITEST_DISTRIBUTED_REDIS_LOG" => f.path },
       ).map(&:value)

--- a/test/integration/redis_retry_mode_integration_test.rb
+++ b/test/integration/redis_retry_mode_integration_test.rb
@@ -3,190 +3,248 @@
 
 require "test_helper"
 
-class RedisRetryModeIntegrationTest < RedisIntegrationTest
-  def test_retry_passing_build_is_noop
-    worker1 = spawn_redis_worker(
-      test_file: "passing_tests.rb",
-      run_id: "test_retry_passing_build_is_noop",
-    ).value
+# Shared test cases for retry mode that should pass identically with and without lazy loading.
+module RedisRetryModeSharedTests
+  class << self
+    def included(base)
+      base.class_eval do
+        define_method("test_retry_passing_build_is_noop_#{loading_mode}") do
+          worker1 = spawn_redis_worker(
+            test_file: "passing_tests.rb",
+            run_id: "#{test_name_prefix}_retry_passing_noop",
+            lazy_load: lazy_load_enabled?,
+          ).value
 
-    assert_worker_successful(worker1)
-    results = combined_results(run_id: "test_retry_passing_build_is_noop")
-    assert_predicate(results, :passed?)
-    assert_equal(100, results.size)
-    assert_equal(100, results.passes)
+          assert_worker_successful(worker1)
+          results = combined_results(run_id: "#{test_name_prefix}_retry_passing_noop")
+          assert_predicate(results, :passed?)
+          assert_equal(100, results.size)
+          assert_equal(100, results.passes)
 
-    # The second attempt should not run any tests becuase they were all successful
-    # on the initial attempt. Size of the rtery run should be 0, other statistics
-    # should be unaffected by the second attempt.
+          # The second attempt should not run any tests because they were all successful
+          # on the initial attempt. Size of the retry run should be 0, other statistics
+          # should be unaffected by the second attempt.
 
-    worker2 = spawn_redis_worker(
-      test_file: "passing_tests.rb",
-      run_id: "test_retry_passing_build_is_noop",
-    ).value
+          worker2 = spawn_redis_worker(
+            test_file: "passing_tests.rb",
+            run_id: "#{test_name_prefix}_retry_passing_noop",
+            lazy_load: lazy_load_enabled?,
+          ).value
 
-    assert_worker_successful(worker2)
-    results = combined_results(run_id: "test_retry_passing_build_is_noop")
-    assert_predicate(results, :passed?)
-    assert_equal(0, results.size)
-    assert_equal(0, results.requeues)
-    assert_equal(100, results.passes)
+          assert_worker_successful(worker2)
+          results = combined_results(run_id: "#{test_name_prefix}_retry_passing_noop")
+          assert_predicate(results, :passed?)
+          assert_equal(0, results.size)
+          assert_equal(0, results.requeues)
+          assert_equal(100, results.passes)
+        end
+
+        define_method("test_retry_failed_build_with_consistently_failing_test_#{loading_mode}") do
+          worker1 = spawn_redis_worker(
+            test_file: "failing_tests.rb",
+            run_id: "#{test_name_prefix}_retry_consistent_fail",
+            lazy_load: lazy_load_enabled?,
+          ).value
+
+          refute_worker_successful(worker1)
+
+          results = combined_results(run_id: "#{test_name_prefix}_retry_consistent_fail")
+          refute_predicate(results, :passed?)
+          assert_equal(100, results.size)
+          assert_equal(99, results.passes)
+          assert_equal(1, results.failures)
+          assert_equal(0, results.requeues)
+
+          # The second attempt should only run the test that failed. The run should
+          # still fail because the second attempt to run the failed tests will also fail.
+
+          worker2 = spawn_redis_worker(
+            test_file: "failing_tests.rb",
+            run_id: "#{test_name_prefix}_retry_consistent_fail",
+            arguments: { "--retry-failures" => "true" },
+            lazy_load: lazy_load_enabled?,
+          ).value
+
+          refute_worker_successful(worker2)
+
+          results = combined_results(run_id: "#{test_name_prefix}_retry_consistent_fail")
+          refute_predicate(results, :passed?)
+          assert_equal(1, results.size)
+          assert_equal(99, results.passes)
+          assert_equal(1, results.failures)
+          assert_equal(1, results.requeues)
+        end
+
+        define_method("test_retry_failed_build_with_retry_mode_disabled_#{loading_mode}") do
+          worker1 = spawn_redis_worker(
+            test_file: "failing_tests.rb",
+            run_id: "#{test_name_prefix}_retry_disabled",
+            lazy_load: lazy_load_enabled?,
+          ).value
+
+          refute_worker_successful(worker1)
+
+          results = combined_results(run_id: "#{test_name_prefix}_retry_disabled")
+          refute_predicate(results, :passed?)
+          assert_equal(100, results.size)
+          assert_equal(99, results.passes)
+          assert_equal(1, results.failures)
+          assert_equal(0, results.requeues)
+
+          # With retry mode disabled, the second attempt will simply do nothing, because the run was already complete.
+
+          worker2 = spawn_redis_worker(
+            test_file: "failing_tests.rb",
+            run_id: "#{test_name_prefix}_retry_disabled",
+            arguments: { "--no-retry-failures" => "true" },
+            lazy_load: lazy_load_enabled?,
+          ).value
+
+          assert_worker_successful(worker2)
+
+          results = combined_results(run_id: "#{test_name_prefix}_retry_disabled")
+          refute_predicate(results, :passed?)
+          assert_equal(0, results.size)
+          assert_equal(99, results.passes)
+          assert_equal(1, results.failures)
+          assert_equal(0, results.requeues)
+        end
+
+        define_method("test_retry_failed_build_with_intermittently_failing_test_#{loading_mode}") do
+          Tempfile.open("#{test_name_prefix}_retry_intermittent") do |f|
+            worker1 = spawn_redis_worker(
+              test_file: "flaky_test.rb",
+              run_id: "#{test_name_prefix}_retry_intermittent",
+              arguments: { "--max-attempts" => "1" },
+              env: { "FLAKY_TRACKER_FILE" => f.path },
+              lazy_load: lazy_load_enabled?,
+            ).value
+
+            refute_worker_successful(worker1)
+
+            results = combined_results(run_id: "#{test_name_prefix}_retry_intermittent")
+            refute_predicate(results, :passed?)
+            assert_equal(100, results.size)
+            assert_equal(99, results.passes)
+            assert_equal(1, results.failures)
+
+            # The second attempt should only retry the failed flaky tests, which will now succeed.
+            # The number of passes increases to 100, the number of failures goes down to 0.
+
+            worker2 = spawn_redis_worker(
+              test_file: "flaky_test.rb",
+              run_id: "#{test_name_prefix}_retry_intermittent",
+              arguments: { "--max-attempts" => "1", "--retry-failures" => "true" },
+              env: { "FLAKY_TRACKER_FILE" => f.path },
+              lazy_load: lazy_load_enabled?,
+            ).value
+
+            assert_worker_successful(worker2)
+
+            results = combined_results(run_id: "#{test_name_prefix}_retry_intermittent")
+            assert_predicate(results, :passed?)
+            assert_equal(1, results.size)
+            assert_equal(100, results.passes)
+            assert_equal(0, results.failures)
+            assert_equal(1, results.requeues)
+          end
+        end
+
+        define_method("test_retry_failed_build_with_multiple_workers_#{loading_mode}") do
+          workers = spawn_redis_workers(
+            count: 3,
+            test_file: "many_failing_tests.rb",
+            run_id: "#{test_name_prefix}_retry_multi_workers",
+            arguments: { "--max-attempts" => "3", "--no-retry-failures" => "true" },
+            lazy_load: lazy_load_enabled?,
+          ).map(&:value)
+
+          assert_some_workers_failed(workers)
+
+          results = combined_results(run_id: "#{test_name_prefix}_retry_multi_workers")
+          refute_predicate(results, :passed?)
+          assert_equal(50, results.passes)
+          assert_equal(25, results.failures)
+          assert_equal(25, results.errors)
+          assert_equal(100, results.unique_runs)
+
+          # We have 50 * 2 = 100 tests being requeued. (3 attempts = 2 requeues)
+          assert_equal(100, results.requeues)
+
+          # The retry run will re-attempt the 25 failures and 25 errors, but the results
+          # will be exactly the same. This integration test mostly guards against race conditions
+          # when running multiple workers simultaneously.
+
+          workers = spawn_redis_workers(
+            count: 3,
+            test_file: "many_failing_tests.rb",
+            run_id: "#{test_name_prefix}_retry_multi_workers",
+            arguments: { "--max-attempts" => "3", "--retry-failures" => "true" },
+            lazy_load: lazy_load_enabled?,
+          ).map(&:value)
+
+          assert_some_workers_failed(workers)
+
+          results = combined_results(run_id: "#{test_name_prefix}_retry_multi_workers")
+          refute_predicate(results, :passed?)
+          assert_equal(50, results.passes)
+          assert_equal(25, results.failures)
+          assert_equal(25, results.errors)
+          assert_equal(100, results.unique_runs)
+
+          # We don't reset the number of requeues between attempts.
+          # So we end up 50*2 + 50 when starting the retry run +
+          # 50*2 for the second attempt = 250 requeues in total.
+          assert_equal(250, results.requeues)
+        end
+      end
+    end
   end
+end
 
-  def test_retry_failed_build_with_consistently_failing_test
-    worker1 = spawn_redis_worker(
-      test_file: "failing_tests.rb",
-      run_id: "test_retry_failed_build_with_consistently_failing_test",
-    ).value
-
-    refute_worker_successful(worker1)
-
-    results = combined_results(run_id: "test_retry_failed_build_with_consistently_failing_test")
-    refute_predicate(results, :passed?)
-    assert_equal(100, results.size)
-    assert_equal(99, results.passes)
-    assert_equal(1, results.failures)
-    assert_equal(0, results.requeues)
-
-    # The second attempt should only run the test that failed. The run should
-    # still fail because the second attempt to run the failed tests will also fail.
-    # STatistics should be unaffected.
-
-    worker2 = spawn_redis_worker(
-      test_file: "failing_tests.rb",
-      run_id: "test_retry_failed_build_with_consistently_failing_test",
-      arguments: { "--retry-failures" => "true" },
-    ).value
-
-    refute_worker_successful(worker2)
-
-    results = combined_results(run_id: "test_retry_failed_build_with_consistently_failing_test")
-    refute_predicate(results, :passed?)
-    assert_equal(1, results.size)
-    assert_equal(99, results.passes)
-    assert_equal(1, results.failures)
-    assert_equal(1, results.requeues)
-  end
-
-  def test_retry_failed_build_with_retry_mode_disabled
-    worker1 = spawn_redis_worker(
-      test_file: "failing_tests.rb",
-      run_id: "test_retry_failed_build_with_retry_mode_disabled",
-    ).value
-
-    refute_worker_successful(worker1)
-
-    results = combined_results(run_id: "test_retry_failed_build_with_retry_mode_disabled")
-    refute_predicate(results, :passed?)
-    assert_equal(100, results.size)
-    assert_equal(99, results.passes)
-    assert_equal(1, results.failures)
-    assert_equal(0, results.requeues)
-
-    # With retry mode disabled, the second attempt will simply do nothing, because the run was already complete.
-
-    worker2 = spawn_redis_worker(
-      test_file: "failing_tests.rb",
-      run_id: "test_retry_failed_build_with_retry_mode_disabled",
-      arguments: { "--no-retry-failures" => "true" },
-    ).value
-
-    assert_worker_successful(worker2)
-
-    results = combined_results(run_id: "test_retry_failed_build_with_retry_mode_disabled")
-    refute_predicate(results, :passed?)
-    assert_equal(0, results.size)
-    assert_equal(99, results.passes)
-    assert_equal(1, results.failures)
-    assert_equal(0, results.requeues)
-  end
-
-  def test_retry_failed_build_with_intermittently_failing_test
-    Tempfile.open("test_intermittently_failing_test_succeeds_after_second_attempt_with_multiple_workers") do |f|
-      worker1 = spawn_redis_worker(
-        test_file: "flaky_test.rb",
-        run_id: "test_retry_failed_build_with_intermittently_failing_test",
-        arguments: { "--max-attempts" => "1" },
-        env: { "FLAKY_TRACKER_FILE" => f.path },
-      ).value
-
-      refute_worker_successful(worker1)
-
-      results = combined_results(run_id: "test_retry_failed_build_with_intermittently_failing_test")
-      refute_predicate(results, :passed?)
-      assert_equal(100, results.size)
-      assert_equal(99, results.passes)
-      assert_equal(1, results.failures)
-
-      # The second attempt should only retry the failed flaky tests, which will now succeed.
-      # The number of passes increases to 100, the number of failures goes down to 0.
-
-      worker2 = spawn_redis_worker(
-        test_file: "flaky_test.rb",
-        run_id: "test_retry_failed_build_with_intermittently_failing_test",
-        arguments: { "--max-attempts" => "1", "--retry-failures" => "true" },
-        env: { "FLAKY_TRACKER_FILE" => f.path },
-      ).value
-
-      assert_worker_successful(worker2)
-
-      results = combined_results(run_id: "test_retry_failed_build_with_intermittently_failing_test")
-      assert_predicate(results, :passed?)
-      assert_equal(1, results.size)
-      assert_equal(100, results.passes)
-      assert_equal(0, results.failures)
-      assert_equal(1, results.requeues)
+# Tests without lazy loading (baseline)
+class RedisRetryModeIntegrationEagerTest < RedisIntegrationTest
+  class << self
+    def loading_mode
+      "eager"
     end
   end
 
-  def test_retry_failed_build_with_multiple_workers
-    workers = spawn_redis_workers(
-      count: 3,
-      test_file: "many_failing_tests.rb",
-      run_id: "test_retry_failed_build_with_multiple_workers",
-      arguments: { "--max-attempts" => "3", "--no-retry-failures" => "true" },
-    ).map(&:value)
-
-    assert_some_workers_failed(workers)
-
-    results = combined_results(run_id: "test_retry_failed_build_with_multiple_workers")
-    refute_predicate(results, :passed?)
-    assert_equal(50, results.passes)
-    assert_equal(25, results.failures)
-    assert_equal(25, results.errors)
-    assert_equal(100, results.unique_runs)
-
-    # We have 50 * 2 = 100 tests being requeued. (3 attempts = 2 requeues)
-    assert_equal(100, results.requeues)
-
-    # The retry run will re-attempt the 25 failures and 25 errors, but the results
-    # will be exactly the same. This integration test mostly guards against race conditions
-    # when running multiple workers simulatanously.
-
-    workers = spawn_redis_workers(
-      count: 3,
-      test_file: "many_failing_tests.rb",
-      run_id: "test_retry_failed_build_with_multiple_workers",
-      arguments: { "--max-attempts" => "3", "--retry-failures" => "true" },
-    ).map(&:value)
-
-    assert_some_workers_failed(workers)
-
-    results = combined_results(run_id: "test_retry_failed_build_with_multiple_workers")
-    refute_predicate(results, :passed?)
-    assert_equal(50, results.passes)
-    assert_equal(25, results.failures)
-    assert_equal(25, results.errors)
-    assert_equal(100, results.unique_runs)
-
-    # We don't reset the number of requeues between attempts.
-    # So we end up 50*2 + 50 when starting the retry run +
-    # 50*2 for the second attempt = 250 requeues in total.
-    assert_equal(250, results.requeues)
+  def lazy_load_enabled?
+    false
   end
 
+  def test_name_prefix
+    "eager"
+  end
+
+  include RedisRetryModeSharedTests
+end
+
+# Tests with lazy loading enabled
+class RedisRetryModeIntegrationLazyTest < RedisIntegrationTest
+  class << self
+    def loading_mode
+      "lazy"
+    end
+  end
+
+  def lazy_load_enabled?
+    true
+  end
+
+  def test_name_prefix
+    "lazy"
+  end
+
+  include RedisRetryModeSharedTests
+end
+
+# Tests that don't need to run in both eager and lazy modes
+# These test specific edge cases around retry behavior that aren't affected by loading mode
+class RedisRetryModeIntegrationTest < RedisIntegrationTest
   def test_retry_attempt_on_run_that_was_cut_short
-    # When we the initial attempt is cut short because we reach the maximum number
+    # When the initial attempt is cut short because we reach the maximum number
     # of failures, we have to decide what to do when a retry is attempted.
     worker1 = spawn_redis_worker(
       test_file: "only_failures.rb",
@@ -204,7 +262,7 @@ class RedisRetryModeIntegrationTest < RedisIntegrationTest
     assert_equal(10, initial_results.failures)
     assert_equal(0, initial_results.requeues)
 
-    # We now attenmpt to retry the 10 failures, even though all 100 tests
+    # We now attempt to retry the 10 failures, even though all 100 tests
     # would have failed if we would not have specified max-attempts.
     worker2 = spawn_redis_worker(
       test_file: "only_failures.rb",
@@ -213,7 +271,7 @@ class RedisRetryModeIntegrationTest < RedisIntegrationTest
     ).value
 
     # In our current implementation, we simply immediately fail the attempt without
-    # running any tests, because we don't know what tests were previosuly not run.
+    # running any tests, because we don't know what tests were previously not run.
     refute_worker_successful(worker2)
     assert_includes(worker2.stdout, "Cannot retry a run that was cut short during the previous attempt.")
 
@@ -228,10 +286,10 @@ class RedisRetryModeIntegrationTest < RedisIntegrationTest
 
   def test_retry_attempt_on_run_that_was_cut_short_with_flaky_tests
     # In a naive implementation of short-circuiting runs, we could run into problems with retry mode.
-    # If we abort a run after X flaky tests, and retry mode would only re-run those flaky tests. it
-    # could easily succeed, even though many tests that would could have failed are not run at all.
+    # If we abort a run after X flaky tests, and retry mode would only re-run those flaky tests, it
+    # could easily succeed, even though many tests that could have failed are not run at all.
     #
-    # This tries tests this worst case sceario. The first 10 tests in the test suite we are executing
+    # This tests this worst case scenario. The first 10 tests in the test suite we are executing
     # are flaky and pass on second attempt. The 11th test consistently fails. We should never get a
     # green build when running this test suite, even if we cut a run short after 10 failing tests.
 
@@ -279,7 +337,7 @@ class RedisRetryModeIntegrationTest < RedisIntegrationTest
         env: { "FLAKY_TRACKER_FILE" => f.path },
       ).value
 
-      # Again, the third attempt shoudl not be successful
+      # Again, the third attempt should not be successful
       refute_worker_successful(worker3)
     end
   end

--- a/test/lib/integration_test.rb
+++ b/test/lib/integration_test.rb
@@ -16,7 +16,8 @@ class IntegrationTest < Minitest::Test
     worker_id: SecureRandom.uuid,
     arguments: {},
     timeout: 10,
-    env: {}
+    env: {},
+    lazy_load: false
   )
     Thread.new do
       Thread.current.report_on_exception = false
@@ -24,12 +25,30 @@ class IntegrationTest < Minitest::Test
       stdout_reader, stdout_writer = IO.pipe
       stdout_thread = Thread.new { stdout_reader.read }
 
+      # Build command based on lazy loading mode
+      if lazy_load
+        # Use wrapper script for lazy loading support
+        # Test files are loaded by the elected leader, not at startup
+        cmd = [
+          RbConfig.ruby,
+          File.join(TEST_FILE_FIXTURES, "runner_wrapper.rb"),
+          test_file,
+        ]
+        worker_env = env.dup
+        arguments = arguments.merge("--lazy-load" => "true")
+      else
+        cmd = [
+          RbConfig.ruby,
+          File.join(TEST_FILE_FIXTURES, test_file),
+        ]
+        worker_env = env
+      end
+
       status = nil
       begin
         pid = T.unsafe(Process).spawn(
-          env,
-          RbConfig.ruby,
-          File.join(TEST_FILE_FIXTURES, test_file),
+          worker_env,
+          *cmd,
           "--verbose",
           "--run-id",
           run_id,

--- a/test/lib/redis_integration_test.rb
+++ b/test/lib/redis_integration_test.rb
@@ -74,7 +74,7 @@ class RedisIntegrationTest < IntegrationTest
     config.coordinator.combined_results
   end
 
-  def spawn_redis_workers(test_file:, run_id:, count:, timeout: 10, arguments: {}, env: {})
+  def spawn_redis_workers(test_file:, run_id:, count:, timeout: 10, arguments: {}, env: {}, lazy_load: false)
     count.times.map do |index|
       spawn_redis_worker(
         test_file: test_file,
@@ -82,11 +82,12 @@ class RedisIntegrationTest < IntegrationTest
         timeout: timeout,
         arguments: arguments,
         env: env.merge("WORKER_INDEX" => index.to_s),
+        lazy_load: lazy_load,
       )
     end
   end
 
-  def spawn_redis_worker(test_file:, run_id:, worker_id: SecureRandom.uuid, arguments: {}, timeout: 10, env: {})
+  def spawn_redis_worker(test_file:, run_id:, worker_id: SecureRandom.uuid, arguments: {}, timeout: 10, env: {}, lazy_load: false)
     spawn_worker(
       test_file: test_file,
       run_id: run_id,
@@ -97,6 +98,7 @@ class RedisIntegrationTest < IntegrationTest
       }.merge(arguments),
       timeout: timeout,
       env: env.merge("MINITEST_COORDINATOR" => @redis_uri),
+      lazy_load: lazy_load,
     )
   end
 end

--- a/test/minitest/distributed/configuration_test.rb
+++ b/test/minitest/distributed/configuration_test.rb
@@ -1,0 +1,69 @@
+# typed: true
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Minitest
+  module Distributed
+    class ConfigurationTest < Minitest::Test
+      def test_lazy_load_defaults_to_false
+        config = Configuration.new
+        refute(config.lazy_load)
+      end
+
+      def test_test_helpers_defaults_to_empty_array
+        config = Configuration.new
+        assert_empty(config.test_helpers)
+      end
+
+      def test_from_env_with_lazy_load_true
+        env = {
+          "MINITEST_LAZY_LOAD" => "true",
+        }
+        config = Configuration.from_env(env)
+        assert(config.lazy_load)
+      end
+
+      def test_from_env_with_lazy_load_false
+        env = {
+          "MINITEST_LAZY_LOAD" => "false",
+        }
+        config = Configuration.from_env(env)
+        refute(config.lazy_load)
+      end
+
+      def test_from_env_with_test_helpers
+        env = {
+          "MINITEST_TEST_HELPERS" => "test/test_helper.rb, test/support/helpers.rb",
+        }
+        config = Configuration.from_env(env)
+        assert_equal(["test/test_helper.rb", "test/support/helpers.rb"], config.test_helpers)
+      end
+
+      def test_from_env_with_empty_test_helpers
+        env = {}
+        config = Configuration.from_env(env)
+        assert_empty(config.test_helpers)
+      end
+
+      def test_test_files_defaults_to_empty_array
+        config = Configuration.new
+        assert_empty(config.test_files)
+      end
+
+      def test_from_env_with_test_files
+        env = {
+          "MINITEST_TEST_FILES" => "/path/to/test1.rb, /path/to/test2.rb",
+        }
+        config = Configuration.from_env(env)
+        assert_equal(["/path/to/test1.rb", "/path/to/test2.rb"], config.test_files)
+      end
+
+      def test_from_env_with_empty_test_files
+        env = {}
+        config = Configuration.from_env(env)
+        assert_empty(config.test_files)
+      end
+    end
+  end
+end

--- a/test/minitest/distributed/defined_runnable_test.rb
+++ b/test/minitest/distributed/defined_runnable_test.rb
@@ -14,6 +14,41 @@ module Minitest
           DefinedRunnable.find_class("Minitest::Distributed::EnqueuedRunnable")
         end
       end
+
+      def test_class_defined_returns_true_for_defined_class
+        assert(DefinedRunnable.class_defined?("Minitest::Distributed::DefinedRunnableTest"))
+        assert(DefinedRunnable.class_defined?("Minitest::Test"))
+        assert(DefinedRunnable.class_defined?("Object"))
+      end
+
+      def test_class_defined_returns_false_for_undefined_class
+        refute(DefinedRunnable.class_defined?("NonExistent::Class"))
+        refute(DefinedRunnable.class_defined?("Minitest::NonExistentClass"))
+      end
+
+      def test_load_class_from_manifest_raises_when_class_not_in_manifest
+        manifest = {}
+
+        error = assert_raises(LazyLoadError) do
+          DefinedRunnable.load_class_from_manifest("NonExistent::Class", manifest)
+        end
+
+        assert_includes(error.message, "Cannot find test file for class 'NonExistent::Class'")
+      end
+
+      def test_load_class_from_manifest_loads_file
+        # Use the fixture file path - load will execute it even if already loaded
+        fixture_path = File.expand_path("../../fixtures/passing_tests.rb", __dir__)
+        manifest = {
+          "PassingTests" => fixture_path,
+        }
+
+        # Should not raise - load always executes the file
+        DefinedRunnable.load_class_from_manifest("PassingTests", manifest)
+
+        # Verify the class is now properly defined
+        assert(DefinedRunnable.class_defined?("PassingTests"))
+      end
     end
   end
 end

--- a/test/minitest/distributed/rake_integration_test.rb
+++ b/test/minitest/distributed/rake_integration_test.rb
@@ -1,0 +1,86 @@
+# typed: true
+# frozen_string_literal: true
+
+require "test_helper"
+require "rake"
+require "rake/testtask"
+require "minitest/distributed/rake_integration"
+
+module Minitest
+  module Distributed
+    class RakeIntegrationTest < Minitest::Test
+      def test_apply_sets_custom_loader
+        task = Rake::TestTask.new(:test_integration) do |t|
+          t.pattern = "test/fixtures/passing_tests.rb"
+        end
+
+        RakeIntegration.apply(task)
+
+        assert_includes(task.run_code, "rake_test_loader.rb")
+        assert(File.exist?(task.run_code.gsub('"', "")), "Loader file should exist")
+      end
+
+      def test_loader_path_is_correct
+        expected_path = File.expand_path("../../../lib/minitest/distributed/rake_test_loader.rb", __dir__)
+        assert_equal(expected_path, RakeIntegration::LOADER_PATH)
+        assert(File.exist?(RakeIntegration::LOADER_PATH), "Loader file should exist at LOADER_PATH")
+      end
+    end
+
+    class RakeTestLoaderTest < Minitest::Test
+      LOADER_PATH = File.expand_path("../../../lib/minitest/distributed/rake_test_loader.rb", __dir__)
+      FIXTURE_PATH = File.expand_path("../../fixtures/passing_tests.rb", __dir__)
+
+      def test_loader_loads_files_without_lazy_load
+        # Run loader in a subprocess without MINITEST_LAZY_LOAD
+        output = run_loader_subprocess(lazy_load: false)
+
+        # Should have loaded the file (class defined)
+        assert_includes(output, "PassingTests class defined: true")
+        # Should NOT have set MINITEST_TEST_FILES
+        assert_includes(output, "MINITEST_TEST_FILES: empty")
+      end
+
+      def test_loader_defers_loading_with_lazy_load
+        # Run loader in a subprocess with MINITEST_LAZY_LOAD=true
+        output = run_loader_subprocess(lazy_load: true)
+
+        # Should NOT have loaded the file (class not defined)
+        assert_includes(output, "PassingTests class defined: false")
+        # Should have set MINITEST_TEST_FILES
+        assert_includes(output, "MINITEST_TEST_FILES: #{FIXTURE_PATH}")
+      end
+
+      private
+
+      def run_loader_subprocess(lazy_load:)
+        env = lazy_load ? { "MINITEST_LAZY_LOAD" => "true" } : {}
+
+        # When lazy_load is true, the loader requires minitest/autorun which
+        # registers an at_exit hook. We stub Minitest.autorun to prevent it
+        # from actually running (we just want to test the loader's behavior).
+        script = <<~RUBY
+          # Prevent minitest from auto-running at exit
+          module Minitest
+            def self.autorun
+              # no-op
+            end
+          end
+
+          ARGV.replace([#{FIXTURE_PATH.inspect}])
+          load #{LOADER_PATH.inspect}
+
+          # Check if class was loaded
+          class_defined = ObjectSpace.each_object(Class).any? { |c| c.name == "PassingTests" }
+          puts "PassingTests class defined: \#{class_defined}"
+
+          # Check MINITEST_TEST_FILES
+          test_files = ENV["MINITEST_TEST_FILES"]
+          puts "MINITEST_TEST_FILES: \#{test_files.to_s.empty? ? 'empty' : test_files}"
+        RUBY
+
+        IO.popen([env, RbConfig.ruby, "-e", script], &:read)
+      end
+    end
+  end
+end

--- a/test/minitest/distributed/test_selector_test.rb
+++ b/test/minitest/distributed/test_selector_test.rb
@@ -1,0 +1,109 @@
+# typed: true
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Minitest
+  module Distributed
+    class TestSelectorTest < Minitest::Test
+      def test_test_manifest_returns_class_to_file_mapping
+        options = {
+          filter: nil,
+          exclude: nil,
+          distributed: Configuration.new,
+        }
+        test_selector = TestSelector.new(options)
+
+        manifest = test_selector.test_manifest
+
+        assert_kind_of(Hash, manifest)
+
+        # The manifest should contain at least this test class
+        assert_includes(manifest.keys, "Minitest::Distributed::TestSelectorTest")
+
+        # The file path should end with this test file
+        file_path = manifest["Minitest::Distributed::TestSelectorTest"]
+        assert(file_path.end_with?("test/minitest/distributed/test_selector_test.rb"), "Expected path to end with test file")
+      end
+
+      def test_test_manifest_returns_same_object_on_subsequent_calls
+        options = {
+          filter: nil,
+          exclude: nil,
+          distributed: Configuration.new,
+        }
+        test_selector = TestSelector.new(options)
+
+        manifest1 = test_selector.test_manifest
+        manifest2 = test_selector.test_manifest
+
+        assert_same(manifest1, manifest2)
+      end
+
+      def test_test_manifest_warns_on_duplicate_class_names
+        # Create two mock runnable classes with the same name but different source locations
+        mock_class1 = Class.new(Minitest::Test) do
+          def self.name
+            "DuplicateTestClass"
+          end
+
+          def self.runnable_methods
+            ["test_from_file1"]
+          end
+        end
+
+        mock_class2 = Class.new(Minitest::Test) do
+          def self.name
+            "DuplicateTestClass"
+          end
+
+          def self.runnable_methods
+            ["test_from_file2"]
+          end
+        end
+
+        # Stub source_location to return different files
+        mock_class1.define_method(:test_from_file1) {}
+        mock_class2.define_method(:test_from_file2) {}
+
+        options = {
+          filter: nil,
+          exclude: nil,
+          distributed: Configuration.new,
+        }
+        test_selector = TestSelector.new(options)
+
+        # Stub runnables to return our mock classes
+        test_selector.stub(:runnables, [mock_class1, mock_class2]) do
+          # Stub source_location_for to return different paths
+          test_selector.stub(:source_location_for, ->(klass) {
+            klass == mock_class1 ? "/path/to/file1.rb" : "/path/to/file2.rb"
+          }) do
+            warning_output = capture_io do
+              test_selector.test_manifest
+            end[1] # stderr is second element
+
+            assert_includes(warning_output, "WARNING: Duplicate class name 'DuplicateTestClass'")
+            assert_includes(warning_output, "/path/to/file1.rb")
+            assert_includes(warning_output, "/path/to/file2.rb")
+          end
+        end
+      end
+
+      def test_test_manifest_no_warning_for_unique_class_names
+        options = {
+          filter: nil,
+          exclude: nil,
+          distributed: Configuration.new,
+        }
+        test_selector = TestSelector.new(options)
+
+        warning_output = capture_io do
+          test_selector.test_manifest
+        end[1] # stderr
+
+        refute_includes(warning_output, "WARNING: Duplicate class name")
+      end
+    end
+  end
+end


### PR DESCRIPTION
 ## Summary

  - Add lazy test loading mode to reduce memory usage on worker nodes in distributed test runs
  - Leader worker loads all test files and builds a manifest mapping class names to file paths
  - Consumer workers only load test files on-demand as they claim tests from the queue
  - Add Rake integration helper to defer test file loading when lazy loading is enabled

  ## Motivation

  For large test suites with many workers, loading all test files on every worker wastes memory. With lazy loading, only the leader needs the full test suite in memory. Consumers load files incrementally, potentially using significantly less memory.

  ### Configuration

  - --lazy-load / MINITEST_LAZY_LOAD=true - Enable lazy loading mode
  - --test-helpers=FILES / MINITEST_TEST_HELPERS - Helper files to load before tests (e.g., test_helper)
  - --test-files=FILES / MINITEST_TEST_FILES - Test file paths (set automatically by RakeIntegration)

  ### Redis coordinator

  - Leader stores test manifest (class name → file path) in Redis
  - Consumers fetch manifest and load files on-demand when claiming tests
  - Track loaded files to avoid reloading
  - Expose leader? and files_loaded_count for reporting

  ### Reporting

  - Worker stats now show: role (leader/consumer), files loaded count, peak memory usage, lazy loading status

  ### Other

  - Warning when duplicate class names are detected across files (would cause issues with lazy loading)
  - Changed default max_attempts from 3 to 1

  ### Testing

  - Wrote unit and integration tests that verify all behavior works with and without lazy loading flag
  - Wrote integration tests that validates decrease in consumer memory usage
  - Ran real builds that validated # of files loaded and memory footprint difference 