### PR TITLE
Cap exponential backoff in consume() at 5s

### DIFF
--- a/lib/minitest/distributed/coordinators/redis_coordinator.rb
+++ b/lib/minitest/distributed/coordinators/redis_coordinator.rb
@@ -243,10 +243,17 @@ module Minitest
             # To make sure we don't end up in a busy loop overwhelming Redis with commands
             # when there is no work to do, we increase the blocking time exponentially,
             # and reset it to the initial value if we processed any tests.
-            if stale_runnables.empty? && fresh_runnables.empty?
-              exponential_backoff <<= 1
+            #
+            # The backoff is capped at MAX_BACKOFF to bound how long a worker can sit
+            # inside a single XREADGROUP BLOCK call. Without a cap, after ~15 empty
+            # iterations the worker is blocked in Redis for 5+ minutes and cannot
+            # re-check `complete?` / `abort?` until the BLOCK returns, which manifests
+            # as a long post-100% teardown hang when pipelined XACKs race the progress
+            # reporter.
+            exponential_backoff = if stale_runnables.empty? && fresh_runnables.empty?
+              next_backoff(exponential_backoff)
             else
-              exponential_backoff = INITIAL_BACKOFF
+              INITIAL_BACKOFF
             end
           end
 
@@ -543,8 +550,20 @@ module Minitest
           @logger ||= T.let(Logger.new(log_path), T.nilable(Logger))
         end
 
+        sig { params(backoff: Integer).returns(Integer) }
+        def next_backoff(backoff)
+          [backoff << 1, MAX_BACKOFF].min
+        end
+
         INITIAL_BACKOFF = 10 # milliseconds
         private_constant :INITIAL_BACKOFF
+
+        # Cap on the XREADGROUP BLOCK timeout used by `consume`. Reached after roughly
+        # 9 consecutive empty iterations (10 ms * 2^9 = 5120 ms). Bounds the worst-case
+        # time a worker can be unresponsive to `complete?` / `abort?` after the queue
+        # is drained.
+        MAX_BACKOFF = 5_000 # milliseconds
+        private_constant :MAX_BACKOFF
       end
     end
   end

--- a/lib/minitest/distributed/coordinators/redis_coordinator.rb
+++ b/lib/minitest/distributed/coordinators/redis_coordinator.rb
@@ -153,63 +153,65 @@ module Minitest
 
           return if consumer_group_exists
 
-          tests = T.let([], T::Array[Minitest::Runnable])
-          tests = if initial_attempt
-            # If this is the first attempt for this run ID, we will schedule the full
-            # test suite as returned by the test selector to run.
+          tests = T.let(
+            if initial_attempt
+              # If this is the first attempt for this run ID, we will schedule the full
+              # test suite as returned by the test selector to run.
 
-            tests_from_selector = test_selector.tests
-            adjust_combined_results(ResultAggregate.new(size: tests_from_selector.size))
-            tests_from_selector
+              tests_from_selector = test_selector.tests
+              adjust_combined_results(ResultAggregate.new(size: tests_from_selector.size))
+              tests_from_selector
 
-          elsif configuration.retry_failures
-            # Before starting a retry attempt, we first check if the previous attempt
-            # was aborted before it was completed. If this is the case, we cannot use
-            # retry mode, and should immediately fail the attempt.
-            if combined_results.abort?
-              # We mark this run as aborted, which causes this worker to not be successful.
-              @aborted = true
+            elsif configuration.retry_failures
+              # Before starting a retry attempt, we first check if the previous attempt
+              # was aborted before it was completed. If this is the case, we cannot use
+              # retry mode, and should immediately fail the attempt.
+              if combined_results.abort?
+                # We mark this run as aborted, which causes this worker to not be successful.
+                @aborted = true
 
-              # We still publish an empty size run to Redis, so if there are any followers,
-              # they will wind down normally. Only the leader will exit
-              # with a non-zero exit status and fail the build; any follower will
-              # exit with status 0.
-              adjust_combined_results(ResultAggregate.new(size: 0))
-              T.let([], T::Array[Minitest::Runnable])
-            else
-              previous_failures, previous_errors, _deleted = redis.multi do |pipeline|
-                pipeline.lrange(list_key(ResultType::Failed.serialize), 0, -1)
-                pipeline.lrange(list_key(ResultType::Error.serialize), 0, -1)
-                pipeline.del(list_key(ResultType::Failed.serialize), list_key(ResultType::Error.serialize))
+                # We still publish an empty size run to Redis, so if there are any followers,
+                # they will wind down normally. Only the leader will exit
+                # with a non-zero exit status and fail the build; any follower will
+                # exit with status 0.
+                adjust_combined_results(ResultAggregate.new(size: 0))
+                []
+              else
+                previous_failures, previous_errors, _deleted = redis.multi do |pipeline|
+                  pipeline.lrange(list_key(ResultType::Failed.serialize), 0, -1)
+                  pipeline.lrange(list_key(ResultType::Error.serialize), 0, -1)
+                  pipeline.del(list_key(ResultType::Failed.serialize), list_key(ResultType::Error.serialize))
+                end
+
+                # We set the `size` key to the number of tests we are planning to schedule.
+                # We also adjust the number of failures and errors back to 0.
+                # We set the number of requeues to the number of tests that failed, so the
+                # run statistics will reflect that we retried some failed test.
+                #
+                # However, normally requeues are not acked, as we expect the test to be acked
+                # by another worker later. This makes the test loop think iot is already done.
+                # To prevent this, we initialize the number of acks negatively, so it evens out
+                # in the statistics.
+                total_failures = previous_failures.length + previous_errors.length
+                adjust_combined_results(ResultAggregate.new(
+                  size: total_failures,
+                  failures: -previous_failures.length,
+                  errors: -previous_errors.length,
+                  requeues: total_failures,
+                ))
+
+                # For subsequent attempts, we check the list of previous failures and
+                # errors, and only schedule to re-run those tests. This allows for faster
+                # retries of potentially flaky tests.
+                test_identifiers_to_retry = T.let(previous_failures + previous_errors, T::Array[String])
+                test_identifiers_to_retry.map { |identifier| DefinedRunnable.from_identifier(identifier) }
               end
-
-              # We set the `size` key to the number of tests we are planning to schedule.
-              # We also adjust the number of failures and errors back to 0.
-              # We set the number of requeues to the number of tests that failed, so the
-              # run statistics will reflect that we retried some failed test.
-              #
-              # However, normally requeues are not acked, as we expect the test to be acked
-              # by another worker later. This makes the test loop think iot is already done.
-              # To prevent this, we initialize the number of acks negatively, so it evens out
-              # in the statistics.
-              total_failures = previous_failures.length + previous_errors.length
-              adjust_combined_results(ResultAggregate.new(
-                size: total_failures,
-                failures: -previous_failures.length,
-                errors: -previous_errors.length,
-                requeues: total_failures,
-              ))
-
-              # For subsequent attempts, we check the list of previous failures and
-              # errors, and only schedule to re-run those tests. This allows for faster
-              # retries of potentially flaky tests.
-              test_identifiers_to_retry = T.let(previous_failures + previous_errors, T::Array[String])
-              test_identifiers_to_retry.map { |identifier| DefinedRunnable.from_identifier(identifier) }
-            end
-          else
-            adjust_combined_results(ResultAggregate.new(size: 0))
-            T.let([], T::Array[Minitest::Runnable])
-          end
+            else
+              adjust_combined_results(ResultAggregate.new(size: 0))
+              []
+            end,
+            T::Array[Minitest::Runnable],
+          )
 
           redis.pipelined do |pipeline|
             tests.each do |test|

--- a/lib/minitest/distributed/version.rb
+++ b/lib/minitest/distributed/version.rb
@@ -3,6 +3,6 @@
 
 module Minitest
   module Distributed
-    VERSION = "0.2.12"
+    VERSION = "0.2.13"
   end
 end

--- a/test/minitest/distributed/coordinators/redis_coordinator_test.rb
+++ b/test/minitest/distributed/coordinators/redis_coordinator_test.rb
@@ -1,0 +1,62 @@
+# typed: true
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Minitest
+  module Distributed
+    module Coordinators
+      class RedisCoordinatorTest < Minitest::Test
+        # Mirror of the private constants from RedisCoordinator. The behavior
+        # tests below also exercise the cap, so any drift in the production
+        # value (e.g. MAX_BACKOFF moves up or down) will fail those tests.
+        EXPECTED_INITIAL_BACKOFF = 10 # milliseconds
+        EXPECTED_MAX_BACKOFF = 5_000 # milliseconds
+
+        def setup
+          @coordinator = RedisCoordinator.new(
+            configuration: Configuration.new(
+              coordinator_uri: URI("redis://localhost/0"),
+              run_id: "test_next_backoff",
+            ),
+          )
+        end
+
+        def test_next_backoff_doubles_below_max
+          assert_equal(20, @coordinator.send(:next_backoff, 10))
+          assert_equal(40, @coordinator.send(:next_backoff, 20))
+          assert_equal(2_560, @coordinator.send(:next_backoff, 1_280))
+        end
+
+        def test_next_backoff_clamps_at_max
+          # Last doubling that stays at or under the cap.
+          assert_operator(@coordinator.send(:next_backoff, EXPECTED_MAX_BACKOFF / 2), :<=, EXPECTED_MAX_BACKOFF)
+          # Doubling that would exceed the cap stays at the cap.
+          assert_equal(EXPECTED_MAX_BACKOFF, @coordinator.send(:next_backoff, EXPECTED_MAX_BACKOFF))
+          assert_equal(EXPECTED_MAX_BACKOFF, @coordinator.send(:next_backoff, EXPECTED_MAX_BACKOFF * 2))
+          assert_equal(EXPECTED_MAX_BACKOFF, @coordinator.send(:next_backoff, 1_000_000))
+        end
+
+        def test_next_backoff_caps_within_a_bounded_number_of_iterations
+          # Sanity check the doubling math: starting from INITIAL_BACKOFF, the cap must
+          # be reached within a small, bounded number of iterations so that consume()
+          # can re-evaluate `complete?` / `abort?` within MAX_BACKOFF of run completion.
+          backoff = T.let(EXPECTED_INITIAL_BACKOFF, Integer)
+          iterations = 0
+          while backoff < EXPECTED_MAX_BACKOFF
+            backoff = T.cast(@coordinator.send(:next_backoff, backoff), Integer)
+            iterations += 1
+            break if iterations > 64 # guard against an unbounded test loop
+          end
+          assert_equal(EXPECTED_MAX_BACKOFF, backoff)
+          assert_operator(
+            iterations,
+            :<=,
+            20,
+            "Expected the backoff to cap within ~20 doublings; got #{iterations}",
+          )
+        end
+      end
+    end
+  end
+end

--- a/test/minitest/distributed/coordinators/redis_coordinator_test.rb
+++ b/test/minitest/distributed/coordinators/redis_coordinator_test.rb
@@ -37,6 +37,47 @@ module Minitest
           assert_equal(EXPECTED_MAX_BACKOFF, @coordinator.send(:next_backoff, 1_000_000))
         end
 
+        def test_consume_routes_backoff_through_next_backoff_and_caps_at_max
+          # Pins the call site of `next_backoff` inside `consume`'s idle-loop path.
+          # Without this test the helper assertions above still pass even if the
+          # `consume` loop reverts to a bare `exponential_backoff <<= 1`, which is
+          # exactly the regression this PR is preventing. We assert that the `block:`
+          # argument actually passed to `claim_fresh_runnables` saturates at
+          # `MAX_BACKOFF`; a revert to unbounded doubling would push the captured
+          # value past 5_000_000 within 20 idle iterations.
+          captured_blocks = T.let([], T::Array[Integer])
+          remaining_idle_iterations = T.let(25, Integer)
+
+          @coordinator.define_singleton_method(:claim_stale_runnables) { [] }
+          @coordinator.define_singleton_method(:claim_fresh_runnables) do |block:|
+            captured_blocks << block
+            []
+          end
+          @coordinator.define_singleton_method(:process_batch) { |*_| }
+          @coordinator.define_singleton_method(:cleanup) {}
+
+          fake_results = Object.new
+          fake_results.define_singleton_method(:complete?) do
+            remaining_idle_iterations -= 1
+            remaining_idle_iterations <= 0
+          end
+          fake_results.define_singleton_method(:abort?) { false }
+          @coordinator.define_singleton_method(:combined_results) { fake_results }
+
+          @coordinator.consume(reporter: Minitest::CompositeReporter.new)
+
+          assert_operator(
+            captured_blocks.length,
+            :>=,
+            20,
+            "Expected consume to run enough idle iterations to saturate the backoff; got #{captured_blocks.length}.",
+          )
+          # Once the backoff reaches MAX_BACKOFF it must stay there. The last five
+          # captures pin the call site: if it were `<<= 1`, these would be growing
+          # powers of two well above MAX_BACKOFF rather than the cap itself.
+          assert_equal([EXPECTED_MAX_BACKOFF] * 5, captured_blocks.last(5))
+        end
+
         def test_next_backoff_caps_within_a_bounded_number_of_iterations
           # Sanity check the doubling math: starting from INITIAL_BACKOFF, the cap must
           # be reached within a small, bounded number of iterations so that consume()


### PR DESCRIPTION
## TL;DR

**Problem.** `Coordinators::RedisCoordinator#consume` doubles its `XREADGROUP BLOCK <ms>` interval on every empty poll with no upper bound. Once doubling has gone on long enough (around 15 empty iterations from the 10 ms start), a single `BLOCK` call can last 5–10 minutes, during which the worker cannot re-check `complete?` / `abort?`. Any transient moment when `complete?` is momentarily false after the queue has functionally drained — pipelined `XACK`s not yet visible, a worker that died holding a claim and not yet reaped, a slow ack write on a high-latency Redis path — is enough to push the worker into one of those multi-minute blocks, where it then sits until the `BLOCK` expires or the platform kills the job. The unbounded `BLOCK` is the amplifier: without it, the next iteration would be a short poll, the worker would re-check on its own, and the same transient inconsistency would heal in milliseconds.

**Fix.** Cap the doubled value at `MAX_BACKOFF = 5_000` ms. Extract the doubling into a private `next_backoff` method so it's unit-testable without a live Redis. Bounds the worst-case unresponsiveness to a single `MAX_BACKOFF` window while keeping the same exponential ramp-up for the common case.

## Details

`Coordinators::RedisCoordinator#consume` doubles `exponential_backoff` on every empty iteration with `exponential_backoff <<= 1` and no upper bound. That value is passed to `redis.xreadgroup(... block: <ms>)`, i.e. Redis `XREADGROUP ... BLOCK <ms>`, which the client implements as `poll()` on the socket.

Starting from `INITIAL_BACKOFF = 10` ms, after 15 consecutive empty iterations a single `BLOCK` call lasts ~5m27s; after 16, ~10m. The `break if combined_results.complete?` and `break if combined_results.abort?` checks only run **after** the `BLOCK` returns, so once a worker has entered a multi-minute `BLOCK` it cannot escape until the `BLOCK` expires or the platform kills the job.

Under the right conditions this can surface as a post-test teardown hang: Minitest reports `N/N 100%`, but `bin/rails test` then sits in `ppoll()` on the coordinator's Redis socket for several minutes until the build times out.  We've observed this path in production. It doesn't happen on every run — it requires the transient inconsistency to land between two specific iterations — but the worst case it leads to is unbounded.

The fix caps the doubled value at `MAX_BACKOFF = 5_000` ms (reached after ~9 iterations, ~10 s of cumulative empty polls). It bounds the worst case where a worker is unresponsive to `complete?` / `abort?` after the queue drains to a single `MAX_BACKOFF` window, while keeping the same exponential ramp-up behaviour for the common case.

The doubling logic is extracted into a private `next_backoff` method so it can be unit-tested without a live Redis. New tests cover the doubling, the clamp, and the bounded iteration count.


## Testing

- Added `test/minitest/distributed/coordinators/redis_coordinator_test.rb` covering: doubling below the cap, clamping at the cap, and the bounded-iteration count.



